### PR TITLE
Add local run history storage layer

### DIFF
--- a/BITACORA.md
+++ b/BITACORA.md
@@ -13,6 +13,11 @@ Each entry should use:
 ## Entries
 
 ---
+**Timestamp:** 2026-03-27 16:09 UTC
+**Author:** Codex
+**Entry:** Applied the substantive PR `#126` review fixes on the run-store branch without deleting prior review context or comments. Hardened `LocalJSONRunStore` against path traversal by validating `run_id`-derived file paths, introduced a typed `RunStatus` enum, narrowed exception handling to concrete parse/validation/file-operation failures, wrapped save-time write failures in an explicit runtime error, and expanded tests for invalid statuses, invalid stored records, path traversal rejection, and write failures. Verified with `bash scripts/run_tests.sh`: `64 passed`, `100.00%` coverage.
+
+---
 **Timestamp:** 2026-03-27 14:30 UTC
 **Author:** Codex
 **Entry:** Closed the remaining implementation gaps for issues `#2`, `#3`, and `#4` on a follow-up branch by making the canonical version stamp portable and explicit as `yyyy.MM.dd HH:mm:ss.SSS`, validating and locating `release-version.txt` deterministically from the backend, shifting bootstrap dependency installation to the package declarations in `backend/pyproject.toml` and `sdk/python/pyproject.toml`, and hardening the CI/release workflows with dependency-path-aware caching, timeout control, artifact upload, and non-empty version-stamp validation.

--- a/backend/src/magnetar_prometheus/history/models.py
+++ b/backend/src/magnetar_prometheus/history/models.py
@@ -1,14 +1,25 @@
-from pydantic import BaseModel, Field
-from typing import Any, Dict, List, Optional
 from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class RunStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
 
 class RunRecord(BaseModel):
     """
     Represents a recorded execution of a workflow.
     """
+
     run_id: str
     workflow_id: str
-    status: str
+    status: RunStatus
     start_time: datetime
     end_time: Optional[datetime] = None
     output_summary: Dict[str, Any] = Field(default_factory=dict)

--- a/backend/src/magnetar_prometheus/run_store.py
+++ b/backend/src/magnetar_prometheus/run_store.py
@@ -3,7 +3,10 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import List, Optional
 
+from pydantic import ValidationError
+
 from magnetar_prometheus.history.models import RunRecord
+
 
 class RunStore(ABC):
     """
@@ -29,27 +32,38 @@ class LocalJSONRunStore(RunStore):
     """
 
     def __init__(self, storage_dir: str = ".run_history"):
-        self.storage_dir = Path(storage_dir)
+        self.storage_dir = Path(storage_dir).resolve()
         self.storage_dir.mkdir(parents=True, exist_ok=True)
 
     def _get_file_path(self, run_id: str) -> Path:
-        return self.storage_dir / f"{run_id}.json"
+        candidate = (self.storage_dir / f"{run_id}.json").resolve()
+        if candidate.parent != self.storage_dir:
+            raise ValueError(f"Invalid run_id '{run_id}' for local run storage")
+        return candidate
 
     def save(self, record: RunRecord) -> None:
         file_path = self._get_file_path(record.run_id)
-        with open(file_path, "w", encoding="utf-8") as f:
-            # model_dump_json handles datetime serialization
-            f.write(record.model_dump_json(indent=2))
+        try:
+            with open(file_path, "w", encoding="utf-8") as f:
+                # model_dump_json handles datetime serialization.
+                f.write(record.model_dump_json(indent=2))
+        except OSError as exc:
+            raise RuntimeError(f"Failed to save record to {file_path}: {exc}") from exc
 
     def get(self, run_id: str) -> Optional[RunRecord]:
-        file_path = self._get_file_path(run_id)
+        try:
+            file_path = self._get_file_path(run_id)
+        except ValueError:
+            return None
+
         if not file_path.is_file():
             return None
+
         try:
             with open(file_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
             return RunRecord(**data)
-        except (json.JSONDecodeError, Exception):
+        except (json.JSONDecodeError, OSError, ValidationError):
             return None
 
     def list(self) -> List[RunRecord]:
@@ -63,9 +77,9 @@ class LocalJSONRunStore(RunStore):
                     with open(file_path, "r", encoding="utf-8") as f:
                         data = json.load(f)
                     records.append(RunRecord(**data))
-                except (json.JSONDecodeError, Exception):
+                except (json.JSONDecodeError, OSError, ValidationError):
                     continue
 
-        # Sort by start_time descending by default
+        # Sort by start_time descending by default.
         records.sort(key=lambda r: r.start_time, reverse=True)
         return records

--- a/backend/tests/test_history_models.py
+++ b/backend/tests/test_history_models.py
@@ -1,7 +1,10 @@
 import json
 from datetime import datetime, timezone
 
-from magnetar_prometheus.history.models import RunRecord
+import pytest
+from pydantic import ValidationError
+
+from magnetar_prometheus.history.models import RunRecord, RunStatus
 
 def test_run_record_serialization():
     start = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
@@ -10,11 +13,11 @@ def test_run_record_serialization():
     record = RunRecord(
         run_id="run-001",
         workflow_id="wf-abc",
-        status="running",
+        status=RunStatus.RUNNING,
         start_time=start,
         end_time=end,
         output_summary={"progress": 50},
-        error_list=[{"msg": "warning 1"}]
+        error_list=[{"msg": "warning 1"}],
     )
 
     # Dump to JSON
@@ -37,13 +40,24 @@ def test_run_record_deserialization():
         "status": "completed",
         "start_time": "2024-01-02T10:00:00Z",
         "output_summary": {},
-        "error_list": []
+        "error_list": [],
     }
 
     record = RunRecord(**json_data)
 
     assert record.run_id == "run-002"
-    assert record.status == "completed"
+    assert record.status == RunStatus.COMPLETED
     assert record.start_time.year == 2024
     assert record.start_time.month == 1
     assert record.end_time is None
+
+def test_run_record_rejects_invalid_status():
+    json_data = {
+        "run_id": "run-003",
+        "workflow_id": "wf-def",
+        "status": "unknown",
+        "start_time": "2024-01-02T10:00:00Z",
+    }
+
+    with pytest.raises(ValidationError, match="status"):
+        RunRecord(**json_data)

--- a/backend/tests/test_run_store.py
+++ b/backend/tests/test_run_store.py
@@ -1,9 +1,10 @@
 import json
-import pytest
+from unittest.mock import patch
 from datetime import datetime, timezone
-from pathlib import Path
 
-from magnetar_prometheus.history.models import RunRecord
+import pytest
+
+from magnetar_prometheus.history.models import RunRecord, RunStatus
 from magnetar_prometheus.run_store import LocalJSONRunStore
 
 
@@ -20,11 +21,11 @@ def sample_record():
     return RunRecord(
         run_id="run-123",
         workflow_id="wf-abc",
-        status="completed",
+        status=RunStatus.COMPLETED,
         start_time=datetime(2023, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
         end_time=datetime(2023, 1, 1, 10, 5, 0, tzinfo=timezone.utc),
         output_summary={"result": "success"},
-        error_list=[]
+        error_list=[],
     )
 
 def test_store_initialization(temp_store_dir):
@@ -43,7 +44,7 @@ def test_save_and_get(store, sample_record):
     assert retrieved is not None
     assert retrieved.run_id == "run-123"
     assert retrieved.workflow_id == "wf-abc"
-    assert retrieved.status == "completed"
+    assert retrieved.status == RunStatus.COMPLETED
     assert retrieved.start_time == sample_record.start_time
     assert retrieved.end_time == sample_record.end_time
     assert retrieved.output_summary == {"result": "success"}
@@ -63,7 +64,7 @@ def test_list_records(store, sample_record):
     record2 = RunRecord(
         run_id="run-456",
         workflow_id="wf-xyz",
-        status="failed",
+        status=RunStatus.FAILED,
         start_time=datetime(2023, 1, 2, 10, 0, 0, tzinfo=timezone.utc),
     )
 
@@ -98,3 +99,27 @@ def test_list_non_existent_dir(tmp_path):
 
     records = store.list()
     assert len(records) == 0
+
+def test_save_wraps_file_write_errors(store, sample_record):
+    with patch("builtins.open", side_effect=OSError("disk full")):
+        with pytest.raises(RuntimeError, match="Failed to save record"):
+            store.save(sample_record)
+
+def test_get_rejects_path_traversal_run_id(store):
+    assert store.get("../escape") is None
+
+def test_list_ignores_invalid_record_shape(store, temp_store_dir):
+    invalid_record = temp_store_dir / "invalid-record.json"
+    invalid_record.write_text(
+        json.dumps(
+            {
+                "run_id": "run-invalid",
+                "workflow_id": "wf-abc",
+                "status": "unknown",
+                "start_time": "2023-01-01T10:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert store.list() == []


### PR DESCRIPTION
### **User description**
This commit adds a basic run-history mechanism for the backend orchestration engine. 

- Created `RunRecord` to encapsulate run context metadata (run id, workflow id, status, start/end times, and output).
- Created `RunStore` abstraction and a file-based `LocalJSONRunStore` that serializes and deserializes the history records securely and correctly.
- Added comprehensive unit tests for both the models and the store, covering edge cases like file system errors or malformed data, bringing test coverage to 100%.

This implementation is independent of `cli.py` and the core `engine.py`, offering a pluggable interface for future capabilities where workflow runs can be persisted and inspected instead of disappearing in terminal output.

---
*PR created automatically by Jules for task [13961096235191102983](https://jules.google.com/task/13961096235191102983) started by @scherenhaenden*


___

### **Description**
- Introduced `RunRecord` model to encapsulate execution metadata for workflows.
- Developed `RunStore` interface and `LocalJSONRunStore` for persistent storage of run history.
- Added extensive unit tests ensuring 100% coverage for models and storage functionality.
- Enhanced documentation with detailed docstrings for clarity on model and store usage.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Introduce RunRecord Model for Execution History</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/src/magnetar_prometheus/history/models.py
<li>Added <code>RunRecord</code> Pydantic model for workflow execution history.<br> <li> Included fields for run metadata such as <code>run_id</code>, <code>workflow_id</code>, <code>status</code>, <br>and timestamps.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarPrometheus/pull/126/files#diff-2eae1b6a66ce229dd52c0b8d7fa3727ce871c265f3bd62994ecd268dfe0e29cc">+15/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>run_store.py</strong><dd><code>Implement RunStore Interface and LocalJSONRunStore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/src/magnetar_prometheus/run_store.py
<li>Created <code>RunStore</code> abstract class for run record management.<br> <li> Implemented <code>LocalJSONRunStore</code> for file-based storage of run records.<br> <li> Added methods for saving, retrieving, and listing run records.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarPrometheus/pull/126/files#diff-639d113c1126b8853e0d1c1d61158fafb5a5fca4d0e6f874bca3965670a97172">+71/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_history_models.py</strong><dd><code>Add Tests for RunRecord Functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/tests/test_history_models.py
<li>Added tests for serialization and deserialization of <code>RunRecord</code>.<br> <li> Verified correct handling of JSON output and input.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarPrometheus/pull/126/files#diff-fe41ec9e7c7a242edbddd2cd67031e74c61db45ff5b6a9d7abd18b524709d76c">+49/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_run_store.py</strong><dd><code>Comprehensive Tests for LocalJSONRunStore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/tests/test_run_store.py
<li>Implemented tests for <code>LocalJSONRunStore</code> functionality.<br> <li> Covered saving, retrieving, and listing records, including error <br>handling.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarPrometheus/pull/126/files#diff-cbcc4d4b809897eb85f4f59f7881d809fec82ad8ef46317d1ecb2ad793d788c4">+100/-0</a>&nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow execution history tracking capability, allowing users to store and retrieve execution records including run identifiers, status, timing information, outputs, and errors.
  * Implemented local file-based persistence for execution history with ability to list all recorded executions.

* **Tests**
  * Added comprehensive test coverage for execution history models and persistence layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->