### PR TITLE
Close remaining implementation gaps for issues 2, 3, and 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   validate:
     name: Validation and Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -20,6 +21,9 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
+          cache-dependency-path: |
+            backend/pyproject.toml
+            sdk/python/pyproject.toml
 
       - name: Bootstrap Environment
         run: bash scripts/bootstrap_python.sh
@@ -29,3 +33,10 @@ jobs:
 
       - name: Run Tests (Enforces 100% Coverage)
         run: bash scripts/run_tests.sh
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            backend/.coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Generate canonical version stamp
         id: version
         run: |
           VERSION_STAMP="$(bash scripts/get_version_stamp.sh)"
+          if [ -z "${VERSION_STAMP}" ]; then
+            echo "scripts/get_version_stamp.sh produced an empty version stamp" >&2
+            exit 1
+          fi
           echo "version_stamp=${VERSION_STAMP}" >> "${GITHUB_OUTPUT}"
           echo "${VERSION_STAMP}" > release-version.txt
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -117,7 +117,7 @@ Current status:
 - The product follows the Magnetar canon for project administration but does not define the canon itself.
 - The repository must expose explicit scripts for running the backend, tests, and bootstrap flows.
 - The runtime should detect missing Python dependencies at startup and install or guide installation automatically when the chosen execution mode permits it.
-- Release and build metadata should use a timestamp-oriented version stamp in the form `yyyy.MM.dd HH:mm:sss`.
+- Release and build metadata should use a timestamp-oriented version stamp in the form `yyyy.MM.dd HH:mm:ss.SSS`.
 - The repository should be pipeline-driven for test, validation, packaging, and release operations.
 
 ## Current Execution Flow
@@ -150,7 +150,7 @@ That means the current product slice is visible mainly through terminal output. 
 The repository follows a strict separation between Python package semantic versions and the canonical version stamp:
 
 - Python packages (`backend` and `sdk`) use standard PEP-440 versioning (e.g., `0.1.0`) for internal metadata and standard toolchain compatibility.
-- The canonical release version stamp for MagnetarPrometheus follows the format `yyyy.MM.dd HH:mm:sss`. This stamp is generated during the delivery lifecycle and is meant for runtime reporting, release metadata, and external logging. It acts as the product-level identifier, while the package-level versions are used primarily for local dependency resolution.
+- The canonical release version stamp for MagnetarPrometheus follows the format `yyyy.MM.dd HH:mm:ss.SSS`. This stamp is generated during the delivery lifecycle and is meant for runtime reporting, release metadata, and external logging. It acts as the product-level identifier, while the package-level versions are used primarily for local dependency resolution.
 
 ## Delivery Automation Constraints
 

--- a/BITACORA.md
+++ b/BITACORA.md
@@ -13,6 +13,11 @@ Each entry should use:
 ## Entries
 
 ---
+**Timestamp:** 2026-03-27 14:30 UTC
+**Author:** Codex
+**Entry:** Closed the remaining implementation gaps for issues `#2`, `#3`, and `#4` on a follow-up branch by making the canonical version stamp portable and explicit as `yyyy.MM.dd HH:mm:ss.SSS`, validating and locating `release-version.txt` deterministically from the backend, shifting bootstrap dependency installation to the package declarations in `backend/pyproject.toml` and `sdk/python/pyproject.toml`, and hardening the CI/release workflows with dependency-path-aware caching, timeout control, artifact upload, and non-empty version-stamp validation.
+
+---
 **Timestamp:** 2026-03-27 14:18 UTC
 **Author:** Codex
 **Entry:** Updated the top-level governance and contribution docs to make the delivery model explicit: MagnetarPrometheus should be advanced in user-incremental slices so that each work round leaves something new runnable, visible, or testable. This was added to `README.md`, `RULES.md`, `WIP_GUIDELINES.md`, `CONTRIBUTING.md`, `PLAN.md`, and `STATUS.md`.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -14,7 +14,7 @@
 - The repository must provide runnable scripts for startup, bootstrap, and test execution flows.
 - The Python runtime must detect missing required libraries during startup.
 - The Python runtime must install missing libraries dynamically when execution policy permits it, or fail with explicit remediation guidance when it does not.
-- The project must use timestamp-based versioning in the format `yyyy.MM.dd HH:mm:sss`.
+- The project must use timestamp-based versioning in the format `yyyy.MM.dd HH:mm:ss.SSS`.
 - The repository must provide automated pipelines for testing, validation, and release flows.
 
 ### Should-Have

--- a/RULES.md
+++ b/RULES.md
@@ -30,7 +30,7 @@ The following files must exist unless an exemption is logged in [BITACORA.md](/h
 
 ## Versioning Standard
 
-- Canonical version and release stamps use the format `yyyy.MM.dd HH:mm:sss`
+- Canonical version and release stamps use the format `yyyy.MM.dd HH:mm:ss.SSS`
 - The same timestamp-oriented format should be reused across release notes, pipeline artifacts, and other operational metadata where practical
 
 ## Branching Conventions

--- a/TESTING.md
+++ b/TESTING.md
@@ -56,7 +56,7 @@ For the current proof of concept, acceptance should be read as “the backend sl
 
 - CI must execute the standard test and validation path on every relevant change
 - coverage enforcement must run in pipeline, not only locally
-- release-oriented pipeline stages should preserve the canonical version stamp format `yyyy.MM.dd HH:mm:sss`
+- release-oriented pipeline stages should preserve the canonical version stamp format `yyyy.MM.dd HH:mm:ss.SSS`
 
 ## Practical Local Validation
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "magnetar-prometheus"
 # Note: This is the PEP-440 semantic version for python packaging.
 # The canonical release version stamp for MagnetarPrometheus follows
-# the 'yyyy.MM.dd HH:mm:sss' format and is generated separately.
+# the 'yyyy.MM.dd HH:mm:ss.SSS' format and is generated separately.
 version = "0.1.0"
 description = "Backend runtime for the MagnetarPrometheus workflow orchestration platform."
 requires-python = ">=3.11"

--- a/backend/src/magnetar_prometheus/version.py
+++ b/backend/src/magnetar_prometheus/version.py
@@ -1,39 +1,58 @@
-import os
 import datetime
+import re
+from pathlib import Path
 from typing import Optional
+
+VERSION_STAMP_PATTERN = re.compile(r"^\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}:\d{2}\.\d{3}$")
+
+
+def _generate_canonical_version_stamp() -> str:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return now.strftime("%Y.%m.%d %H:%M:%S.") + f"{now.microsecond // 1000:03d}"
+
+
+def _candidate_release_version_paths(override_path: Optional[str] = None) -> list[Path]:
+    candidates: list[Path] = []
+
+    if override_path:
+        candidates.append(Path(override_path))
+
+    module_path = Path(__file__).resolve()
+    for parent in module_path.parents:
+        candidates.append(parent / "release-version.txt")
+
+    unique_candidates: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        resolved = candidate.resolve(strict=False)
+        if resolved not in seen:
+            unique_candidates.append(candidate)
+            seen.add(resolved)
+
+    return unique_candidates
+
 
 def get_canonical_version_stamp(override_path: Optional[str] = None) -> str:
     """
     Returns the canonical version stamp for MagnetarPrometheus.
 
-    The format follows the rule: yyyy.MM.dd HH:mm:sss
+    The format follows the rule: yyyy.MM.dd HH:mm:ss.SSS
 
-    It first attempts to read this from a 'release-version.txt' file
-    (which may be dropped by the CI/release pipeline at the repo root or current directory).
-    If the file does not exist, it falls back to generating the current UTC timestamp
-    dynamically.
+    It first attempts to read this from a canonical `release-version.txt` file,
+    located deterministically by searching upward from this module toward the
+    repository root. If the file is missing, unreadable, empty, or malformed, it
+    falls back to generating the current UTC timestamp dynamically.
     """
-    paths_to_check = [
-        "release-version.txt",
-        "../release-version.txt",
-        "../../release-version.txt",
-    ]
+    for path in _candidate_release_version_paths(override_path):
+        if not path.exists():
+            continue
 
-    if override_path:
-        paths_to_check.insert(0, override_path)
+        try:
+            content = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
 
-    for path in paths_to_check:
-        if os.path.exists(path):
-            try:
-                with open(path, "r", encoding="utf-8") as f:
-                    content = f.read().strip()
-                    if content:
-                        return content
-            except OSError:
-                continue
+        if content and VERSION_STAMP_PATTERN.fullmatch(content):
+            return content
 
-    # Fallback to current UTC time
-    now = datetime.datetime.now(datetime.timezone.utc)
-    # Ensure zero-padding for milliseconds
-    ms = f"{now.microsecond // 1000:03d}"
-    return now.strftime(f"%Y.%m.%d %H:%M:%S{ms}")
+    return _generate_canonical_version_stamp()

--- a/backend/tests/test_version.py
+++ b/backend/tests/test_version.py
@@ -1,16 +1,18 @@
-import os
-import pytest
 import datetime
-from unittest.mock import patch, mock_open
+from pathlib import Path
+from unittest.mock import patch
 
-from magnetar_prometheus.version import get_canonical_version_stamp
+from magnetar_prometheus.version import (
+    _candidate_release_version_paths,
+    get_canonical_version_stamp,
+)
 
 def test_get_canonical_version_stamp_from_file(tmp_path):
     version_file = tmp_path / "release-version.txt"
-    version_file.write_text("2026.03.26 12:00:00123")
+    version_file.write_text("2026.03.26 12:00:00.123")
 
     version = get_canonical_version_stamp(override_path=str(version_file))
-    assert version == "2026.03.26 12:00:00123"
+    assert version == "2026.03.26 12:00:00.123"
 
 def test_get_canonical_version_stamp_empty_file(tmp_path):
     version_file = tmp_path / "release-version.txt"
@@ -19,22 +21,30 @@ def test_get_canonical_version_stamp_empty_file(tmp_path):
     # with an empty file it should fallback to dynamic timestamp
     # we just check the format of the output
     version = get_canonical_version_stamp(override_path=str(version_file))
-    assert len(version) >= 22 # yyyy.MM.dd HH:mm:sss is 22 chars
-    assert "." in version
-    assert ":" in version
+    assert len(version) == 23  # yyyy.MM.dd HH:mm:ss.SSS
+    assert version.count(".") == 3
+    assert version.count(":") == 2
 
 def test_get_canonical_version_stamp_file_read_error(tmp_path):
     version_file = tmp_path / "release-version.txt"
-    version_file.write_text("2026.03.26 12:00:00123")
+    version_file.write_text("2026.03.26 12:00:00.123")
 
     # Mock open to raise an OSError when reading the file
-    with patch("builtins.open", side_effect=OSError("Permission denied")):
+    with patch("pathlib.Path.read_text", side_effect=OSError("Permission denied")):
         version = get_canonical_version_stamp(override_path=str(version_file))
-        assert len(version) >= 22
+        assert len(version) == 23
+
+def test_get_canonical_version_stamp_invalid_file_falls_back(tmp_path):
+    version_file = tmp_path / "release-version.txt"
+    version_file.write_text("not-a-version-stamp")
+
+    version = get_canonical_version_stamp(override_path=str(version_file))
+    assert version != "not-a-version-stamp"
+    assert len(version) == 23
 
 def test_get_canonical_version_stamp_dynamic_fallback():
     # Make sure we don't accidentally read a real file in the repo
-    with patch("os.path.exists", return_value=False):
+    with patch("magnetar_prometheus.version._candidate_release_version_paths", return_value=[]):
         # We mock datetime to ensure consistent generation
         fixed_dt = datetime.datetime(2026, 3, 26, 12, 5, 10, 45000, tzinfo=datetime.timezone.utc)
         class MockDateTime:
@@ -44,4 +54,15 @@ def test_get_canonical_version_stamp_dynamic_fallback():
 
         with patch("magnetar_prometheus.version.datetime.datetime", MockDateTime):
             version = get_canonical_version_stamp()
-            assert version == "2026.03.26 12:05:10045"
+            assert version == "2026.03.26 12:05:10.045"
+
+def test_candidate_release_version_paths_searches_upward(tmp_path):
+    module_file = tmp_path / "backend" / "src" / "magnetar_prometheus" / "version.py"
+    module_file.parent.mkdir(parents=True)
+    module_file.write_text("# test module")
+
+    with patch("magnetar_prometheus.version.__file__", str(module_file)):
+        candidates = _candidate_release_version_paths()
+
+    assert module_file.parent / "release-version.txt" in candidates
+    assert (tmp_path / "release-version.txt") in candidates

--- a/scripts/bootstrap_python.sh
+++ b/scripts/bootstrap_python.sh
@@ -20,10 +20,11 @@ fi
 
 # Keep bootstrap simple and deterministic for the PoC:
 # 1. prepare an isolated virtual environment
-# 2. install the runtime and test dependencies needed by the current slice
+# 2. install the runtime and test dependencies from the canonical package declarations
 # 3. execute the Python-side startup check so missing imports are surfaced early
 echo "Installing runtime and testing dependencies..."
-"${VENV_PIP}" install setuptools wheel pydantic PyYAML pytest pytest-cov
+"${VENV_PIP}" install setuptools wheel
+"${VENV_PIP}" install --no-build-isolation -e "${ROOT_DIR}/sdk/python[dev]" -e "${ROOT_DIR}/backend[dev]"
 
 echo "Running startup check (which may trigger automatic dependency installation if missing)..."
 PYTHONPATH="${ROOT_DIR}/sdk/python/src:${ROOT_DIR}/backend/src" \

--- a/scripts/get_version_stamp.sh
+++ b/scripts/get_version_stamp.sh
@@ -2,5 +2,12 @@
 set -euo pipefail
 
 # This script generates the canonical version stamp for MagnetarPrometheus.
-# Format: yyyy.MM.dd HH:mm:sss
-date -u '+%Y.%m.%d %H:%M:%S%3N'
+# Format: yyyy.MM.dd HH:mm:ss.SSS
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+"${PYTHON_BIN}" - <<'PY'
+from datetime import datetime, timezone
+
+now = datetime.now(timezone.utc)
+print(now.strftime("%Y.%m.%d %H:%M:%S.") + f"{now.microsecond // 1000:03d}")
+PY

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "magnetar-prometheus-sdk"
 # Note: This is the PEP-440 semantic version for python packaging.
 # The canonical release version stamp for MagnetarPrometheus follows
-# the 'yyyy.MM.dd HH:mm:sss' format and is generated separately.
+# the 'yyyy.MM.dd HH:mm:ss.SSS' format and is generated separately.
 version = "0.1.0"
 description = "Shared contracts and models for the MagnetarPrometheus workflow orchestration platform."
 requires-python = ">=3.11"

--- a/sdk/schemas/README.md
+++ b/sdk/schemas/README.md
@@ -11,6 +11,6 @@ Initial expected contents:
 
 ## Versioning Notes
 
-The runtime schemas and metadata use canonical version stamps rather than simple semantic versions when representing high-level product builds. The canonical format is `yyyy.MM.dd HH:mm:sss`.
+The runtime schemas and metadata use canonical version stamps rather than simple semantic versions when representing high-level product builds. The canonical format is `yyyy.MM.dd HH:mm:ss.SSS`.
 
 Note that standard Python components in the SDK will continue to use PEP-440 compliant semantic versions (`0.1.0`) in their `pyproject.toml` files for packaging purposes, while exposing the product canonical version dynamically at runtime.


### PR DESCRIPTION
### **User description**
## Summary
This PR closes the remaining implementation gaps around issues #2, #3, and #4 without claiming functionality the repository still does not have.

What this PR does:
- makes the canonical version stamp portable and explicit as `yyyy.MM.dd HH:mm:ss.SSS`
- aligns the active versioning docs and package comments to that exact format
- makes backend version-stamp loading deterministic and validated instead of CWD-relative and permissive
- shifts bootstrap dependency installation to the canonical package declarations in `backend/pyproject.toml` and `sdk/python/pyproject.toml`
- hardens CI caching and artifact handling
- hardens the release-metadata workflow so an empty version stamp fails the job

What this PR does not do:
- it does not create GitHub Release objects
- it does not implement a full release publishing pipeline

That remaining gap is intentional in this PR body because the current repository workflow is still metadata-oriented, not a full release publication flow.

## Issue Reference
- refs #2
- refs #3
- refs #4

## Validation
- `bash scripts/bootstrap_python.sh`
- `bash scripts/run_tests.sh`
- result: `53 passed`, `100.00%` coverage

## Notes
The issues should be closed only after the fixes are merged into `master`.


___

### **Description**
- Enhanced CI workflows with timeout controls and coverage report uploads.
- Improved release workflows with validation for empty version stamps.
- Updated documentation to reflect the new timestamp format for versioning.
- Enhanced version stamp generation and validation logic in the backend.
- Updated tests to ensure correctness of versioning functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>CI Workflow Enhancements with Coverage Reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml
<li>Added a timeout for the validation job.<br> <li> Specified cache dependency paths for Python dependencies.<br> <li> Added a step to upload the coverage report.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarPrometheus/pull/129/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+11/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Release Workflow Improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml
<li>Added Python setup step for the release job.<br> <li> Implemented validation for empty version stamps.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarPrometheus/pull/129/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Project Configuration Update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/pyproject.toml
- Updated comments to reflect the new version stamp format.



</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarPrometheus/pull/129/files#diff-9f2cf60079756e94b31dbaeb145297215236d3c0135647163c2e51b80fd81551">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>version.py</strong><dd><code>Version Stamp Generation and Validation Enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/src/magnetar_prometheus/version.py
<li>Added a regex pattern for validating version stamps.<br> <li> Improved logic for generating and retrieving version stamps.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarPrometheus/pull/129/files#diff-83cb9d8239db0a8ff0c57c11d588decb409140ee0406cec0e9363d9c55908673">+48/-29</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>get_version_stamp.sh</strong><dd><code>Version Stamp Generation Script Update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/get_version_stamp.sh
- Updated script to generate version stamps in the new format.



</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarPrometheus/pull/129/files#diff-ecd435ffe389ad659a52df8ffc507f6c374e390a0b3db2196405a50bcc309bb7">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ARCHITECTURE.md</strong><dd><code>Documentation Update for Versioning Standards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ARCHITECTURE.md
- Updated version stamp format to `yyyy.MM.dd HH:mm:ss.SSS`.



</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarPrometheus/pull/129/files#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_version.py</strong><dd><code>Tests for Version Stamp Functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/tests/test_version.py
<li>Updated tests to reflect the new version stamp format.<br> <li> Added tests for candidate release version path logic.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/MagnetarPrometheus/pull/129/files#diff-2e7250f83dc65077927d3f32907c08610e2bc0e6ff7913d84c54707947800e33">+35/-14</a>&nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipelines with timeout enforcement, improved dependency caching, and coverage artifact uploads.
  * Refactored dependency installation to use package declarations instead of hardcoded lists.

* **Bug Fixes**
  * Improved version stamp discovery with deterministic upward directory tree search.
  * Added strict validation for version stamp format and content.

* **Documentation**
  * Standardized version stamp format to `yyyy.MM.dd HH:mm:ss.SSS` across all documentation and configuration files.

* **Tests**
  * Updated test suite to validate strict version stamp format and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->