### PR TITLE
Restore heavy documentation on API loopback branch

### DIFF
--- a/BITACORA.md
+++ b/BITACORA.md
@@ -15,6 +15,11 @@ Each entry should use:
 ---
 **Timestamp:** 2026-04-02 15:09 CEST
 **Author:** Codex
+**Entry:** Addressed the second actionable PR `#159` review fix by making `backend/tests/test_documentation_contract.py` target the specific CLI API-mode test docstrings through AST parsing instead of searching the entire file text. The documentation-contract guard remains strict, but it is now tied to the exact tests whose policy explanations it is meant to protect.
+
+---
+**Timestamp:** 2026-04-02 15:09 CEST
+**Author:** Codex
 **Entry:** Addressed the first actionable PR `#159` review fix by deriving the CLI `--host` help text from `DEFAULT_API_HOST` instead of hardcoding `127.0.0.1`. This keeps the operator-facing help text aligned with the centralized default host policy and prevents future drift between code behavior and CLI messaging.
 
 ---

--- a/BITACORA.md
+++ b/BITACORA.md
@@ -15,6 +15,11 @@ Each entry should use:
 ---
 **Timestamp:** 2026-04-02 14:48 CEST
 **Author:** Codex
+**Entry:** Added a documentation-contract test for the PR `#152` API/CLI surface so future cleanup passes cannot silently shrink the heavy intent comments below the repository's preferred threshold. Restored long-form rationale in `api/server.py`, `cli.py`, and `backend/tests/test_cli.py`, and wired the new validator into `scripts/run_tests.sh`.
+
+---
+**Timestamp:** 2026-04-02 14:48 CEST
+**Author:** Codex
 **Entry:** Addressed the remaining PR `#152` cleanup feedback by centralizing the default API loopback host in `api/server.py` and reusing it from the CLI, then trimming a few overly repetitive comments/docstrings in the CLI, API server, and CLI tests without weakening the documented security intent.
 
 ---

--- a/BITACORA.md
+++ b/BITACORA.md
@@ -13,6 +13,11 @@ Each entry should use:
 ## Entries
 
 ---
+**Timestamp:** 2026-04-02 15:11 CEST
+**Author:** Codex
+**Entry:** Addressed the fourth actionable PR `#159` review fix by replacing the `parents[2]` repository-root assumption in `backend/tests/test_documentation_contract.py` with an upward search for stable repo markers (`BITACORA.md` and `backend/pyproject.toml`). The documentation-contract test is now less brittle if the test package layout moves later.
+
+---
 **Timestamp:** 2026-04-02 15:10 CEST
 **Author:** Codex
 **Entry:** Addressed the third actionable PR `#159` review fix by extending `backend/tests/test_documentation_contract.py` to protect the long policy comment above `DEFAULT_API_HOST` in `api/server.py`. The branch now treats that explanatory comment block as part of the enforced documentation contract instead of leaving it unguarded.

--- a/BITACORA.md
+++ b/BITACORA.md
@@ -13,6 +13,11 @@ Each entry should use:
 ## Entries
 
 ---
+**Timestamp:** 2026-04-02 15:09 CEST
+**Author:** Codex
+**Entry:** Addressed the first actionable PR `#159` review fix by deriving the CLI `--host` help text from `DEFAULT_API_HOST` instead of hardcoding `127.0.0.1`. This keeps the operator-facing help text aligned with the centralized default host policy and prevents future drift between code behavior and CLI messaging.
+
+---
 **Timestamp:** 2026-04-02 14:48 CEST
 **Author:** Codex
 **Entry:** Added a documentation-contract test for the PR `#152` API/CLI surface so future cleanup passes cannot silently shrink the heavy intent comments below the repository's preferred threshold. Restored long-form rationale in `api/server.py`, `cli.py`, and `backend/tests/test_cli.py`, and wired the new validator into `scripts/run_tests.sh`.

--- a/BITACORA.md
+++ b/BITACORA.md
@@ -13,6 +13,11 @@ Each entry should use:
 ## Entries
 
 ---
+**Timestamp:** 2026-04-02 15:10 CEST
+**Author:** Codex
+**Entry:** Addressed the third actionable PR `#159` review fix by extending `backend/tests/test_documentation_contract.py` to protect the long policy comment above `DEFAULT_API_HOST` in `api/server.py`. The branch now treats that explanatory comment block as part of the enforced documentation contract instead of leaving it unguarded.
+
+---
 **Timestamp:** 2026-04-02 15:09 CEST
 **Author:** Codex
 **Entry:** Addressed the second actionable PR `#159` review fix by making `backend/tests/test_documentation_contract.py` target the specific CLI API-mode test docstrings through AST parsing instead of searching the entire file text. The documentation-contract guard remains strict, but it is now tied to the exact tests whose policy explanations it is meant to protect.

--- a/TESTING.md
+++ b/TESTING.md
@@ -4,6 +4,11 @@
 
 The current automated test suite validates the backend proof-of-concept slice very aggressively, but it does not validate a finished end-user product because that product surface does not exist yet.
 
+For a few touched operational files, the backend pytest suite now also enforces a narrow
+documentation contract. That check exists because docstring coverage alone was not enough to
+stop intent comments from being trimmed below the repository's preferred "explain the why,
+how, what, and keep-it-this-way constraint" threshold.
+
 What is covered well today:
 
 - workflow model validation

--- a/backend/src/magnetar_prometheus/api/server.py
+++ b/backend/src/magnetar_prometheus/api/server.py
@@ -37,6 +37,24 @@ from magnetar_prometheus.modules.example_registry import register_all_example_st
 from magnetar_prometheus.registry.step_registry import StepRegistry
 
 logger = logging.getLogger(__name__)
+
+# Keep the loopback default in one constant so every local-service surface in the repository
+# speaks the same language about what "safe by default" means for this API slice.
+#
+# This comment is intentionally long because this exact value is the sort of thing that drifts
+# when multiple agents touch the same feature over time. One agent changes the server default,
+# another edits CLI help text, a third updates tests, and suddenly the codebase contains three
+# different "defaults" that all look individually plausible. The project does not want that.
+#
+# The real policy is:
+# - the unauthenticated `/run-example` endpoint stays local by default
+# - broader exposure is supported, but only when an operator asks for it explicitly
+# - the CLI, the server implementation, and the tests should all derive that default from one
+#   source of truth so that intent cannot quietly fork across files
+#
+# Keep this constant unless the repository grows a clearly better configuration object that
+# centrally owns bind defaults for every surface. A shorter comment would save a few lines but
+# would not carry enough context to stop the next "harmless cleanup" from reintroducing drift.
 DEFAULT_API_HOST = "127.0.0.1"
 
 
@@ -195,12 +213,28 @@ class MagnetarAPIHandler(BaseHTTPRequestHandler):
 def run_server(port: int = 8000, host: str = DEFAULT_API_HOST) -> None:
     """Start the minimal local MagnetarPrometheus API server.
 
-    The loopback default keeps the unauthenticated ``/run-example`` endpoint local unless
-    the caller explicitly chooses a broader binding.
+    This function is intentionally explicit about bind behavior because the bind behavior is
+    part of the product's current security posture, not an incidental implementation detail.
+
+    The default host stays on the loopback interface because the current API surface is a
+    local-development and local-validation tool. It exposes an unauthenticated example-run
+    endpoint, so broader binding should remain an operator choice that is visible at the call
+    site rather than a quiet default hidden in framework configuration.
+
+    Future agents should read this docstring as a constraint:
+    - do not casually replace the explicit ``host`` parameter with an implicit global default
+    - do not broaden the default binding without intentionally changing the product policy
+    - do not collapse the lifecycle handling into a shorter bootstrap if that makes shutdown,
+      logging, or review-time reasoning about the bind behavior harder
+
+    In other words, keep this function boring and obvious unless there is a clearly better
+    application-level bootstrap that preserves the same explicit security story.
 
     Args:
         port: TCP port to listen on. Defaults to ``8000``.
-        host: Network interface to bind to. Defaults to ``DEFAULT_API_HOST``.
+        host: Network interface to bind to. Defaults to ``DEFAULT_API_HOST`` so local-only
+            access remains the out-of-the-box behavior. Passing a broader host is supported,
+            but it should remain an explicit opt-in decision.
     """
     server_address = (host, port)
     httpd = MagnetarAPIServer(server_address, MagnetarAPIHandler)

--- a/backend/src/magnetar_prometheus/cli.py
+++ b/backend/src/magnetar_prometheus/cli.py
@@ -139,7 +139,7 @@ def main():
         default=DEFAULT_API_HOST,
         help=(
             "Network interface to bind the API server to "
-            "(defaults to 127.0.0.1 for local-only access). "
+            f"(defaults to {DEFAULT_API_HOST} for local-only access). "
             "Pass 0.0.0.0 to bind on all interfaces."
         ),
     )

--- a/backend/src/magnetar_prometheus/cli.py
+++ b/backend/src/magnetar_prometheus/cli.py
@@ -52,7 +52,14 @@ def _print_summary(workflow_path: Path, result_context: dict) -> None:
     operators frequently run the CLI directly from a terminal, and a second crash inside the
     renderer would hide the original workflow failure behind a formatting bug.
     """
-    # Tolerate partial engine output so summary rendering never hides the original failure.
+    # This summary path is intentionally defensive because it is the last layer between a
+    # broken workflow and the operator reading the terminal. If a future refactor assumes the
+    # engine always returns a perfectly complete context, the CLI can end up masking the real
+    # workflow failure behind a second formatting failure.
+    #
+    # Keep the fallback `.get(... ) or {}` / `.get(... ) or []` pattern unless the engine
+    # contract changes and the tests are updated to prove summary mode still tolerates partial
+    # failure output. The slightly repetitive style here is serving a resilience goal.
     run_info = result_context.get("run") or {}
     history = result_context.get("history") or []
     data = result_context.get("data") or {}
@@ -120,7 +127,12 @@ def main():
         help="Port to run the API server on (defaults to 8000).",
     )
 
-    # Reuse the server default so local-only binding stays the safe path by default.
+    # Reuse the server-level constant instead of copying the loopback literal here.
+    #
+    # This is intentionally verbose because default values are one of the easiest places for
+    # multi-agent drift to creep in. If the CLI and the server each carry their own literal,
+    # one future edit can make help text, runtime behavior, and tests disagree without anyone
+    # noticing immediately. Importing the constant makes the alignment explicit in code.
     parser.add_argument(
         "--host",
         type=str,
@@ -134,10 +146,16 @@ def main():
 
     args = parser.parse_args()
 
-    # The `--api` path is a deliberate short-circuit: once the operator asks for server mode,
-    # the CLI must not continue into workflow loading or execution. Startup failures are
-    # normalized here so they follow the same stderr + exit-code contract as the rest of the
-    # command-line interface.
+    # The `--api` path is a deliberate short-circuit and should remain obviously so.
+    #
+    # Why this block is intentionally spelled out:
+    # - API mode is a different command mode, not just "workflow run plus one more flag"
+    # - startup failures should be normalized as CLI-facing stderr output rather than leaked as
+    #   raw lower-level tracebacks
+    # - the parsed host should be forwarded explicitly so the call site documents the actual
+    #   binding choice the operator made
+    # - the `return` must remain because dropping it would allow API mode to leak into the
+    #   normal one-shot workflow path after server startup logic
     if args.api:
         try:
             run_server(port=args.port, host=args.host)

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -216,8 +216,15 @@ def test_cli_api_startup_failure(capsys):
 def test_cli_api_flag(mock_run_server, mock_load_workflow):
     """Test that `--api` switches the CLI into long-running server mode.
 
-    The test covers both delegation to `run_server` and the required short-circuit that keeps
-    the normal workflow-loading path from running in API mode.
+    This test deliberately protects multiple policy boundaries at once:
+
+    - the CLI must delegate to `run_server` when `--api` is present
+    - the safe loopback default must be forwarded explicitly at the call boundary
+    - the normal workflow-loading path must not run at all in API mode
+
+    The docstring stays long on purpose because this is exactly the kind of test that looks
+    "too wordy" to a cleanup pass and then quietly loses the context for why the extra
+    assertions are there. The branch is protecting a mode boundary, not just a mock call.
     """
     with patch("sys.argv", ["cli.py", "--api", "--port", "9000"]):
         main()
@@ -230,8 +237,13 @@ def test_cli_api_flag(mock_run_server, mock_load_workflow):
 def test_cli_api_flag_custom_host(mock_run_server):
     """Test that ``--host`` is forwarded to ``run_server`` when provided explicitly.
 
-    The default loopback path is already covered by ``test_cli_api_flag``. This case protects
-    the explicit opt-in path for broader bindings.
+    The default loopback path is already covered by ``test_cli_api_flag``. This companion case
+    protects the opposite boundary: users are allowed to opt into a broader bind, but only
+    when they request it explicitly.
+
+    This should remain documented in detail because it is easy for a future simplification to
+    preserve the default-host path while accidentally dropping the explicit-host forwarding
+    behavior and thereby collapsing operator intent back to the default.
     """
     with patch("sys.argv", ["cli.py", "--api", "--port", "9000", "--host", "0.0.0.0"]):
         main()

--- a/backend/tests/test_documentation_contract.py
+++ b/backend/tests/test_documentation_contract.py
@@ -71,6 +71,15 @@ def test_run_server_docstring_preserves_binding_policy() -> None:
     assert "security" in docstring or "policy" in docstring
 
 
+def test_default_api_host_comment_preserves_policy_context() -> None:
+    """Ensure the DEFAULT_API_HOST comment keeps the bind-policy rationale stable."""
+    source_text = API_SERVER_PATH.read_text(encoding="utf-8")
+
+    assert "DEFAULT_API_HOST" in source_text
+    assert "Keep the loopback default in one constant" in source_text
+    assert "unauthenticated `/run-example` endpoint stays local by default" in source_text
+
+
 def test_cli_api_mode_tests_keep_policy_explanation() -> None:
     """Ensure the CLI API-mode tests keep their long-form policy narrative."""
     api_default_doc = _read_function_docstring(CLI_TEST_PATH, "test_cli_api_flag")

--- a/backend/tests/test_documentation_contract.py
+++ b/backend/tests/test_documentation_contract.py
@@ -1,0 +1,80 @@
+"""
+Documentation-contract tests for high-context operational files.
+
+Why this file exists in this form:
+
+- Docstring coverage alone is not enough to preserve the repository's documentation standard.
+  A file can have 100 percent coverage and still lose the long-form rationale that tells the
+  next agent why the code is shaped this way and which parts are policy rather than accident.
+- The CLI/API loopback branch already demonstrated that failure mode: a cleanup pass shortened
+  comments that the user explicitly wanted to stay heavy and explanatory. This file exists so
+  that the same regression becomes test-visible instead of only review-visible.
+- The assertions here are intentionally narrow. They do not try to judge all prose quality in
+  the repository. They enforce a documentation contract only for the touched API/CLI surface
+  where the policy rationale is important and easy to erode.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI_PATH = REPO_ROOT / "backend" / "src" / "magnetar_prometheus" / "cli.py"
+API_SERVER_PATH = REPO_ROOT / "backend" / "src" / "magnetar_prometheus" / "api" / "server.py"
+CLI_TEST_PATH = REPO_ROOT / "backend" / "tests" / "test_cli.py"
+
+
+def _read_module_docstring(path: Path) -> str:
+    """Return the top-level module docstring for a Python file."""
+    module = ast.parse(path.read_text(encoding="utf-8"))
+    return ast.get_docstring(module) or ""
+
+
+def _read_function_docstring(path: Path, function_name: str) -> str:
+    """Return the docstring for a named top-level function."""
+    module = ast.parse(path.read_text(encoding="utf-8"))
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == function_name:
+            return ast.get_docstring(node) or ""
+    return ""
+
+
+def test_cli_module_docstring_stays_high_context() -> None:
+    """Ensure the CLI module keeps a long-form intent header."""
+    docstring = _read_module_docstring(CLI_PATH)
+
+    assert len([line for line in docstring.splitlines() if line.strip()]) >= 12
+    assert "Why this file exists in this form:" in docstring
+    assert "shortest executable path" in docstring
+    assert "application bootstrap layer" in docstring
+
+
+def test_api_server_module_docstring_stays_high_context() -> None:
+    """Ensure the API server module keeps the long-form rationale for the local HTTP slice."""
+    docstring = _read_module_docstring(API_SERVER_PATH)
+
+    assert len([line for line in docstring.splitlines() if line.strip()]) >= 12
+    assert "Why this file exists in this form:" in docstring
+    assert "standard-library ``http.server`` machinery" in docstring
+    assert "Error handling is deliberately conservative" in docstring
+
+
+def test_run_server_docstring_preserves_binding_policy() -> None:
+    """Ensure the bind-policy explanation remains explicit in ``run_server``."""
+    docstring = _read_function_docstring(API_SERVER_PATH, "run_server")
+
+    assert len([line for line in docstring.splitlines() if line.strip()]) >= 10
+    assert "loopback interface" in docstring
+    assert "operator" in docstring
+    assert "security" in docstring or "policy" in docstring
+
+
+def test_cli_api_mode_tests_keep_policy_explanation() -> None:
+    """Ensure the CLI API-mode tests keep their long-form policy narrative."""
+    source_text = CLI_TEST_PATH.read_text(encoding="utf-8")
+
+    assert "This test deliberately protects multiple policy boundaries at once" in source_text
+    assert "safe loopback default" in source_text
+    assert "users are allowed to opt into a broader bind" in source_text

--- a/backend/tests/test_documentation_contract.py
+++ b/backend/tests/test_documentation_contract.py
@@ -20,7 +20,20 @@ import ast
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+def _find_repo_root(start_path: Path) -> Path:
+    """Walk upward until the repository root markers are found.
+
+    This avoids hardcoding a fragile parent-depth assumption into the documentation-contract
+    tests. The branch is deliberately using repo markers that should remain stable even if the
+    test package or backend layout is reorganized.
+    """
+    for candidate in (start_path, *start_path.parents):
+        if (candidate / "BITACORA.md").is_file() and (candidate / "backend" / "pyproject.toml").is_file():
+            return candidate
+    raise AssertionError("Could not locate repository root for documentation-contract tests.")
+
+
+REPO_ROOT = _find_repo_root(Path(__file__).resolve())
 CLI_PATH = REPO_ROOT / "backend" / "src" / "magnetar_prometheus" / "cli.py"
 API_SERVER_PATH = REPO_ROOT / "backend" / "src" / "magnetar_prometheus" / "api" / "server.py"
 CLI_TEST_PATH = REPO_ROOT / "backend" / "tests" / "test_cli.py"

--- a/backend/tests/test_documentation_contract.py
+++ b/backend/tests/test_documentation_contract.py
@@ -73,8 +73,11 @@ def test_run_server_docstring_preserves_binding_policy() -> None:
 
 def test_cli_api_mode_tests_keep_policy_explanation() -> None:
     """Ensure the CLI API-mode tests keep their long-form policy narrative."""
-    source_text = CLI_TEST_PATH.read_text(encoding="utf-8")
+    api_default_doc = _read_function_docstring(CLI_TEST_PATH, "test_cli_api_flag")
+    api_custom_host_doc = _read_function_docstring(
+        CLI_TEST_PATH, "test_cli_api_flag_custom_host"
+    )
 
-    assert "This test deliberately protects multiple policy boundaries at once" in source_text
-    assert "safe loopback default" in source_text
-    assert "users are allowed to opt into a broader bind" in source_text
+    assert "This test deliberately protects multiple policy boundaries at once" in api_default_doc
+    assert "safe loopback default" in api_default_doc
+    assert "users are allowed to opt into a broader bind" in api_custom_host_doc


### PR DESCRIPTION
## User description
The previous PR fixed the loopback binding behavior, but a follow-up cleanup pass trimmed the intent comments far below the repository's preferred standard. This follow-up restores heavy explanation in the touched API/CLI files and adds an automated guard so future comment-thinning passes fail in CI instead of being caught only in review.

## What this follow-up changes
- restores long-form rationale in `backend/src/magnetar_prometheus/api/server.py`
- restores long-form rationale in `backend/src/magnetar_prometheus/cli.py`
- restores long-form rationale in `backend/tests/test_cli.py`
- adds `backend/tests/test_documentation_contract.py` to enforce that these files keep their high-context explanation
- keeps the earlier `DEFAULT_API_HOST` centralization intact
- updates `TESTING.md` and `BITACORA.md` to document the new documentation-contract check

## Why this exists
The repo standard is not merely "some docstrings exist." For touched operational files, the comments are supposed to explain:
- what the code does
- why it exists
- why it was implemented this way
- which policy or operator behavior it protects
- why it should stay like this unless a clearly better replacement exists

The new documentation-contract test is intentionally narrow and pragmatic. It protects the exact API/CLI surface that already regressed, instead of pretending to be a perfect generic prose-quality linter.

## Validation
- `bash scripts/run_tests.sh`
- Result: `92 passed`, `100.00%` coverage

## Summary by Sourcery

Reinstate high-context documentation around the API loopback and CLI behavior and add a test-enforced documentation contract for these operational surfaces.

Documentation:
- Expand rationale comments and docstrings in the API server, CLI, and CLI API-mode tests to clarify binding policy, failure handling, and mode boundaries.
- Document the new documentation-contract check and its purpose in TESTING.md and log the change in BITACORA.md.

Tests:
- Introduce a documentation-contract test module that asserts minimum length and key rationale phrases for critical API/CLI docstrings and comments so future cleanups cannot silently strip this context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced API documentation with clearer security posture and default loopback binding behavior.
  * Improved CLI documentation with explicit operational guidance.
  * Strengthened documentation standards across the codebase.

* **Tests**
  * Added automated documentation contract validation to enforce quality and consistency standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->