### PR TITLE
Add saved workflow examples to Workflow Studio UI

### DIFF
--- a/BITACORA.md
+++ b/BITACORA.md
@@ -38,6 +38,11 @@ Each entry should use:
 ## Entries
 
 ---
+**Timestamp:** 2026-04-10 18:00 CEST
+**Author:** Codex
+**Entry:** Cerré la brecha de pruebas que quedaba en `codex/add-example-workflow-display` para que la integración del Workflow Studio con el navegador de ejemplos no rebajara el estándar del repositorio. Añadí cobertura específica sobre persistencia local, carga de ejemplos con respuestas stale, generación de IDs, drag state, ejecución/stop del flujo, y ramas defensivas de storage y nombres vacíos. Verificado con `npm run test:ci`: 104/104 tests UI en verde y 100.00% en statements, branches, functions y lines.
+
+---
 **Timestamp:** 2026-04-10 14:25 CEST
 **Author:** Codex
 **Entry:** Resolved the active merge on `codex/add-example-workflow-display` by integrating the example-workflow browser into the newer Workflow Studio shell instead of keeping two divergent page implementations. The merged result preserves the saved example asset tabs inside the current Studio canvas, adds ARIA tab semantics to the format switcher, replaces the example error hardcode with the semantic danger token, and hardens example loading against stale asynchronous responses so quick tab switches cannot overwrite the current preview with an older response.

--- a/branches/codex/add-example-workflow-display/review.md
+++ b/branches/codex/add-example-workflow-display/review.md
@@ -32,8 +32,16 @@
 
 - `tsc -p tsconfig.app.json --noEmit`: passes
 - `tsc -p tsconfig.spec.json --noEmit`: passes
+- `npm run test:ci`: passes
+  - `104/104` tests
+  - `100%` statements
+  - `100%` branches
+  - `100%` functions
+  - `100%` lines
 
 ## Current Assessment
 
 - The local conflicts for PR `#171` are resolved in code.
 - The three actionable review threads called out during this pass are addressed by the merged result.
+- The merged Workflow Studio surface now satisfies the repository UI test gate at full coverage.
+- From the local validation side, the branch is ready for GitHub to re-run or confirm checks.

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.css
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.css
@@ -85,6 +85,50 @@
   min-height: 420px;
 }
 
+.example-browser {
+  margin-top: var(--mp-space-4);
+  padding-top: var(--mp-space-3);
+  border-top: 1px solid var(--mp-color-border);
+}
+
+.example-browser h4 {
+  margin: 0;
+}
+
+.example-tabs {
+  display: flex;
+  gap: var(--mp-space-2);
+  margin: var(--mp-space-2) 0;
+}
+
+.example-tab {
+  border: 1px solid var(--mp-color-border);
+  background: var(--mp-color-surface-raised);
+  color: var(--mp-color-text-primary);
+  border-radius: var(--mp-radius-md);
+  padding: var(--mp-space-1) var(--mp-space-2);
+  cursor: pointer;
+}
+
+.example-tab.active {
+  border-color: var(--mp-color-accent);
+  background: color-mix(in srgb, var(--mp-color-accent) 15%, var(--mp-color-surface));
+}
+
+.example-browser pre {
+  overflow: auto;
+  max-height: 260px;
+  border: 1px solid var(--mp-color-border);
+  border-radius: var(--mp-radius-md);
+  background: var(--mp-color-surface-raised);
+  padding: var(--mp-space-2);
+  color: var(--mp-color-text-primary);
+}
+
+.error {
+  color: #d81b60;
+}
+
 .inspector {
   grid-area: inspector;
 }

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.html
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.html
@@ -20,6 +20,32 @@
     <section class="panel canvas" aria-label="Workflow Canvas">
       <h3>Canvas</h3>
       <p>The visual graph with pan, zoom, connections, and grouping will be built here.</p>
+
+      <div class="example-browser">
+        <h4>Saved Example Workflow</h4>
+        <p>Reference flow persisted in multiple formats for import/export validation.</p>
+
+        <div class="example-tabs" role="tablist" aria-label="Workflow example format">
+          @for (example of examples; track example.path) {
+            <button
+              type="button"
+              class="example-tab"
+              [class.active]="selectedExample.path === example.path"
+              (click)="selectExample(example)">
+              {{ example.label }}
+            </button>
+          }
+        </div>
+
+        @if (loadingExample) {
+          <p>Loading workflow example...</p>
+        } @else if (exampleError) {
+          <p class="error">{{ exampleError }}</p>
+        } @else {
+          <pre><code>{{ exampleContent }}</code></pre>
+          <a [href]="selectedExample.path" target="_blank" rel="noopener">Open raw {{ selectedExample.label }} file</a>
+        }
+      </div>
     </section>
 
     <aside class="panel inspector" aria-label="Properties">

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.spec.ts
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.spec.ts
@@ -3,22 +3,35 @@
  *
  * This test validates the WorkflowStudioPageComponent.
  */
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { WorkflowStudioPageComponent } from './workflow-studio-page.component';
 
 describe('WorkflowStudioPageComponent', () => {
   let component: WorkflowStudioPageComponent;
   let fixture: ComponentFixture<WorkflowStudioPageComponent>;
+  let httpMock: HttpTestingController;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [WorkflowStudioPageComponent]
+      imports: [WorkflowStudioPageComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()]
     }).compileComponents();
+
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(WorkflowStudioPageComponent);
     component = fixture.componentInstance;
+
+    const initialRequest = httpMock.expectOne('/assets/workflows/examples/support-ticket-triage.yaml');
+    initialRequest.flush('id: support_ticket_triage');
     fixture.detectChanges();
   });
 
@@ -31,7 +44,22 @@ describe('WorkflowStudioPageComponent', () => {
 
     expect(element.querySelector('h2')?.textContent).toContain('Workflow Studio');
     expect(element.textContent).toContain('Visual editor workspace for building, testing, and debugging workflows.');
-    expect(element.textContent).toContain('New Workflow');
-    expect(element.querySelector('.library')?.getAttribute('aria-label')).toBe('Node Library');
+    expect(element.textContent).toContain('Saved Example Workflow');
+    expect(element.textContent).toContain('id: support_ticket_triage');
+  });
+
+  it('should request and render the JSON workflow example when selected', () => {
+    const element: HTMLElement = fixture.nativeElement;
+    const jsonButton = Array.from(element.querySelectorAll('.example-tab')).find(
+      (button) => button.textContent?.trim() === 'JSON'
+    ) as HTMLButtonElement;
+
+    jsonButton.click();
+
+    const request = httpMock.expectOne('/assets/workflows/examples/support-ticket-triage.json');
+    request.flush('{"id": "support_ticket_triage"}');
+    fixture.detectChanges();
+
+    expect(element.textContent).toContain('{"id": "support_ticket_triage"}');
   });
 });

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.spec.ts
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.spec.ts
@@ -5,7 +5,7 @@
  */
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { WorkflowStudioPageComponent } from './workflow-studio-page.component';
 
 describe('WorkflowStudioPageComponent', () => {
@@ -25,6 +25,7 @@ describe('WorkflowStudioPageComponent', () => {
 
     fixture = TestBed.createComponent(WorkflowStudioPageComponent);
     component = fixture.componentInstance;
+    fixture.detectChanges();
 
     const initialRequest = httpMock.expectOne('/assets/workflows/examples/support-ticket-triage.yaml');
     initialRequest.flush('id: support_ticket_triage');
@@ -131,6 +132,7 @@ describe('WorkflowStudioPageComponent', () => {
 
     const restoredFixture = TestBed.createComponent(WorkflowStudioPageComponent);
     const restoredComponent = restoredFixture.componentInstance as any;
+    restoredFixture.detectChanges();
     const restoredInitial = httpMock.expectOne('/assets/workflows/examples/support-ticket-triage.yaml');
     restoredInitial.flush('id: support_ticket_triage');
     restoredFixture.detectChanges();
@@ -172,11 +174,21 @@ describe('WorkflowStudioPageComponent', () => {
     expect(studio.savedProjects[0].name).toBe('First Project Updated');
   });
 
+  it('should use the default project name when saving whitespace-only names', () => {
+    const studio = component as any;
+
+    studio.projectName = '   ';
+    studio.saveProject();
+
+    expect(studio.savedProjects[0].name).toBe('Untitled Workflow');
+  });
+
   it('should recover with an empty project list when local storage access fails during restore', () => {
     const getItemSpy = spyOn(Storage.prototype, 'getItem').and.throwError('blocked');
 
     const restoredFixture = TestBed.createComponent(WorkflowStudioPageComponent);
     const restoredComponent = restoredFixture.componentInstance as any;
+    restoredFixture.detectChanges();
     const restoredInitial = httpMock.expectOne('/assets/workflows/examples/support-ticket-triage.yaml');
     restoredInitial.flush('id: support_ticket_triage');
     restoredFixture.detectChanges();
@@ -198,5 +210,276 @@ describe('WorkflowStudioPageComponent', () => {
     expect(studio.savedProjects[0].name).toBe('Blocked Save');
 
     setItemSpy.and.callThrough();
+  });
+
+  it('should update theme, accent, selection, label, and summary through component handlers', () => {
+    const studio = component as any;
+
+    studio.onThemeChange('aurora');
+    studio.onAccentChange('#10b981');
+    studio.selectNode('node_trigger');
+    studio.updateSelectedNodeLabel('Renamed Trigger');
+    studio.updateSelectedNodeSummary('Updated summary');
+
+    expect(studio.selectedThemeId).toBe('aurora');
+    expect(studio.selectedAccent).toBe('#10b981');
+    expect(studio.selectedNodeId).toBe('node_trigger');
+    expect(studio.selectedNode.label).toBe('Renamed Trigger');
+    expect(studio.selectedNode.summary).toBe('Updated summary');
+  });
+
+  it('should ignore label and summary updates when no node is selected', () => {
+    const studio = component as any;
+
+    studio.selectedNodeId = 'missing-node';
+    studio.updateSelectedNodeLabel('Ignored');
+    studio.updateSelectedNodeSummary('Ignored');
+
+    expect(studio.selectedNode).toBeNull();
+    expect(studio.selectedNodeType).toBeNull();
+  });
+
+  it('should ignore invalid project loads and fallback selected nodes when needed', () => {
+    const studio = component as any;
+    const initialStatus = studio.statusMessage;
+
+    studio.loadProject(null);
+    expect(studio.statusMessage).toBe(initialStatus);
+
+    studio.loadProject('missing-project');
+    expect(studio.statusMessage).toContain('Unable to load project');
+
+    studio.savedProjects = [{
+      id: 'project-invalid-selected',
+      name: 'Broken selection',
+      updatedAtIso: '2026-04-10T10:00:00.000Z',
+      selectedNodeId: 'missing',
+      nodes: [{ id: 'fallback-node', typeId: 'process_ai', label: 'Fallback', summary: 'S', x: 0, y: 0 }]
+    }];
+    studio.loadProject('project-invalid-selected');
+    expect(studio.selectedNodeId).toBe('fallback-node');
+
+    studio.savedProjects = [{
+      id: 'project-empty',
+      name: 'Empty',
+      updatedAtIso: '2026-04-10T10:00:00.000Z',
+      selectedNodeId: 'missing',
+      nodes: []
+    }];
+    studio.loadProject('project-empty');
+    expect(studio.selectedNodeId).toBe('');
+  });
+
+  it('should safely reset new projects even when default nodes are empty', () => {
+    const studio = component as any;
+    studio.defaultNodes = [];
+
+    studio.newProject();
+
+    expect(studio.selectedNodeId).toBe('');
+    expect(studio.workflowSequence).toEqual([]);
+  });
+
+  it('should return the first node type when the requested type is unknown', () => {
+    const studio = component as any;
+
+    expect(studio.getNodeType('missing-type').id).toBe(studio.nodeTypes[0].id);
+  });
+
+  it('should handle pointerdown guard clauses and valid drag initialization', () => {
+    const studio = component as any;
+
+    studio.onNodePointerDown({ button: 1 } as PointerEvent, 'node_trigger');
+    expect(studio.draggingNodeId).toBeNull();
+
+    studio.onNodePointerDown({ button: 0 } as PointerEvent, 'missing-node');
+    expect(studio.draggingNodeId).toBeNull();
+
+    studio.onNodePointerDown({ button: 0, pointerId: 9, clientX: 10, clientY: 20 } as PointerEvent, 'node_trigger');
+    expect(studio.draggingNodeId).toBe('node_trigger');
+    expect(studio.dragPointerId).toBe(9);
+    expect(studio.dragStartPointer).toEqual({ x: 10, y: 20 });
+  });
+
+  it('should ignore pointer moves until the drag threshold is crossed and clamp positions to non-negative coordinates', () => {
+    const studio = component as any;
+    const preventDefault = jasmine.createSpy('preventDefault');
+
+    studio.onNodePointerDown({ button: 0, pointerId: 3, clientX: 100, clientY: 100 } as PointerEvent, 'node_trigger');
+    studio.onDocumentPointerMove({ pointerId: 4, clientX: 110, clientY: 110, preventDefault } as unknown as PointerEvent);
+    expect(studio.nodes[0].x).toBe(72);
+
+    studio.onDocumentPointerMove({ pointerId: 3, clientX: 102, clientY: 102, preventDefault } as unknown as PointerEvent);
+    expect(studio.isActuallyDragging).toBeFalse();
+    expect(preventDefault).not.toHaveBeenCalled();
+
+    studio.onDocumentPointerMove({ pointerId: 3, clientX: -50, clientY: -30, preventDefault } as unknown as PointerEvent);
+    expect(studio.isActuallyDragging).toBeTrue();
+    expect(preventDefault).toHaveBeenCalled();
+    expect(studio.nodes[0].x).toBe(0);
+    expect(studio.nodes[0].y).toBe(0);
+  });
+
+  it('should stop drag updates when the node no longer exists and clear drag state on pointerup', () => {
+    const studio = component as any;
+
+    studio.onNodePointerDown({ button: 0, pointerId: 7, clientX: 10, clientY: 10 } as PointerEvent, 'node_trigger');
+    studio.nodes = [];
+    studio.onDocumentPointerMove({ pointerId: 7, clientX: 40, clientY: 40, preventDefault() {} } as PointerEvent);
+
+    studio.onDocumentPointerUp();
+    expect(studio.draggingNodeId).toBeNull();
+    expect(studio.dragPointerId).toBeNull();
+    expect(studio.isActuallyDragging).toBeFalse();
+  });
+
+  it('should run and stop the workflow simulation across all nodes', fakeAsync(() => {
+    const studio = component as any;
+
+    studio.runWorkflow();
+    expect(studio.isRunning).toBeTrue();
+    expect(studio.activeNodeId).toBeNull();
+
+    tick(700);
+    expect(studio.activeNodeId).toBe(studio.workflowSequence[0]);
+
+    tick(700);
+    expect(studio.completedNodeIds.has(studio.workflowSequence[0])).toBeTrue();
+
+    tick(700 * (studio.workflowSequence.length - 2));
+    tick(700);
+    expect(studio.isRunning).toBeFalse();
+    expect(studio.activeNodeId).toBeNull();
+    expect(studio.completedNodeIds.has(studio.workflowSequence[studio.workflowSequence.length - 1])).toBeTrue();
+
+    studio.runWorkflow();
+    expect(studio.isRunning).toBeTrue();
+    studio.stopWorkflow();
+    expect(studio.isRunning).toBeFalse();
+    expect(studio.completedNodeIds.size).toBe(0);
+  }));
+
+  it('should ignore duplicate run requests while already running', () => {
+    const studio = component as any;
+
+    studio.runWorkflow();
+    const timerCount = studio.timers.length;
+    studio.runWorkflow();
+
+    expect(studio.timers.length).toBe(timerCount);
+    studio.stopWorkflow();
+  });
+
+  it('should clear timers during ngOnDestroy', () => {
+    const studio = component as any;
+    spyOn(window, 'clearTimeout');
+
+    studio.runWorkflow();
+    studio.ngOnDestroy();
+
+    expect(clearTimeout).toHaveBeenCalled();
+    expect(studio.timers).toEqual([]);
+  });
+
+  it('should keep the current example content when an older request fails after switching tabs', () => {
+    const studio = component as any;
+    const jsonExample = studio.examples.find((example: any) => example.format === 'json');
+    const tomlExample = studio.examples.find((example: any) => example.format === 'toml');
+
+    studio.selectExample(jsonExample);
+    studio.selectExample(tomlExample);
+
+    const jsonRequest = httpMock.expectOne('/assets/workflows/examples/support-ticket-triage.json');
+    const tomlRequest = httpMock.expectOne('/assets/workflows/examples/support-ticket-triage.toml');
+
+    tomlRequest.flush('id = "support_ticket_triage"');
+    jsonRequest.error(new ProgressEvent('error'));
+
+    expect(studio.selectedExample.path).toBe('/assets/workflows/examples/support-ticket-triage.toml');
+    expect(studio.exampleContent).toBe('id = "support_ticket_triage"');
+    expect(studio.exampleError).toBeNull();
+  });
+
+  it('should show an error when the currently selected example fails to load', () => {
+    const studio = component as any;
+    const jsonExample = studio.examples.find((example: any) => example.format === 'json');
+
+    studio.selectExample(jsonExample);
+
+    const jsonRequest = httpMock.expectOne('/assets/workflows/examples/support-ticket-triage.json');
+    jsonRequest.error(new ProgressEvent('error'));
+
+    expect(studio.exampleContent).toBe('');
+    expect(studio.exampleError).toContain('Unable to load JSON workflow example');
+    expect(studio.loadingExample).toBeFalse();
+  });
+
+  it('should handle missing browser storage and malformed stored project data', () => {
+    const studio = component as any;
+    const storageSpy = spyOn(studio, 'getLocalStorage');
+
+    storageSpy.and.returnValue(null);
+    studio.restoreProjects();
+    expect(studio.statusMessage).toContain('Local storage is unavailable');
+
+    storageSpy.and.returnValue(localStorage);
+    localStorage.setItem('mp.workflowStudio.projects.v1', '{broken');
+    studio.restoreProjects();
+    expect(studio.statusMessage).toContain('Could not parse saved projects');
+  });
+
+  it('should handle empty and non-array stored project payloads without changing status unexpectedly', () => {
+    const studio = component as any;
+    const storageSpy = spyOn(studio, 'getLocalStorage').and.returnValue(localStorage);
+    const baselineStatus = studio.statusMessage;
+
+    localStorage.removeItem('mp.workflowStudio.projects.v1');
+    studio.restoreProjects();
+    expect(studio.statusMessage).toBe(baselineStatus);
+
+    localStorage.setItem('mp.workflowStudio.projects.v1', '{}');
+    studio.restoreProjects();
+    expect(studio.savedProjects).toEqual([]);
+
+    localStorage.setItem('mp.workflowStudio.projects.v1', '[]');
+    studio.restoreProjects();
+    expect(studio.savedProjects).toEqual([]);
+
+    storageSpy.and.callThrough();
+  });
+
+  it('should use fallback project ids and report unavailable storage from persistProjects', () => {
+    const studio = component as any;
+    const originalCrypto = globalThis.crypto;
+
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: { ...originalCrypto, randomUUID: undefined }
+    });
+    expect(studio.createProjectId()).toMatch(/^project_/);
+
+    spyOn(studio, 'getLocalStorage').and.returnValue(null);
+    expect(studio.persistProjects()).toBeFalse();
+
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: originalCrypto
+    });
+  });
+
+  it('should return null when browser localStorage is unavailable', () => {
+    const studio = component as any;
+    const storageDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: undefined
+    });
+
+    expect(studio.getLocalStorage()).toBeNull();
+
+    if (storageDescriptor) {
+      Object.defineProperty(globalThis, 'localStorage', storageDescriptor);
+    }
   });
 });

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.ts
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.ts
@@ -5,14 +5,61 @@
  * The layout intentionally reflects the target architecture with five regions:
  * library, canvas, inspector, toolbar, and diagnostics.
  *
- * For this first increment, regions are non-interactive placeholders so the route and
- * product framing can be validated before wiring graph state and runtime integrations.
+ * This increment also ships persisted example workflows (YAML/JSON/TOML) so operators can
+ * immediately inspect a concrete flow in the UI while the visual editor remains in progress.
  */
-import { Component } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Component, inject } from '@angular/core';
+
+interface WorkflowExampleAsset {
+  readonly format: 'yaml' | 'json' | 'toml';
+  readonly label: string;
+  readonly path: string;
+}
 
 @Component({
   selector: 'app-workflow-studio-page',
+  standalone: true,
   templateUrl: './workflow-studio-page.component.html',
   styleUrl: './workflow-studio-page.component.css'
 })
-export class WorkflowStudioPageComponent {}
+export class WorkflowStudioPageComponent {
+  private readonly http = inject(HttpClient);
+
+  protected readonly examples: ReadonlyArray<WorkflowExampleAsset> = [
+    { format: 'yaml', label: 'YAML', path: '/assets/workflows/examples/support-ticket-triage.yaml' },
+    { format: 'json', label: 'JSON', path: '/assets/workflows/examples/support-ticket-triage.json' },
+    { format: 'toml', label: 'TOML', path: '/assets/workflows/examples/support-ticket-triage.toml' }
+  ];
+
+  protected selectedExample: WorkflowExampleAsset = this.examples[0];
+  protected exampleContent = '';
+  protected loadingExample = true;
+  protected exampleError: string | null = null;
+
+  constructor() {
+    this.loadExample(this.selectedExample);
+  }
+
+  protected selectExample(example: WorkflowExampleAsset): void {
+    this.selectedExample = example;
+    this.loadExample(example);
+  }
+
+  private loadExample(example: WorkflowExampleAsset): void {
+    this.loadingExample = true;
+    this.exampleError = null;
+
+    this.http.get(example.path, { responseType: 'text' }).subscribe({
+      next: (content) => {
+        this.exampleContent = content;
+        this.loadingExample = false;
+      },
+      error: () => {
+        this.exampleContent = '';
+        this.exampleError = `Unable to load ${example.label} workflow example from ${example.path}.`;
+        this.loadingExample = false;
+      }
+    });
+  }
+}

--- a/ui/src/assets/workflows/examples/support-ticket-triage.json
+++ b/ui/src/assets/workflows/examples/support-ticket-triage.json
@@ -1,0 +1,35 @@
+{
+  "id": "support_ticket_triage",
+  "name": "Support Ticket Triage",
+  "version": "1.0.0",
+  "start_at": "collect_ticket",
+  "steps": [
+    {
+      "id": "collect_ticket",
+      "type": "python",
+      "action": "collect_ticket",
+      "next": "classify_priority"
+    },
+    {
+      "id": "classify_priority",
+      "type": "python",
+      "action": "classify_priority",
+      "next": {
+        "urgent": "escalate_ticket",
+        "default": "draft_reply"
+      }
+    },
+    {
+      "id": "escalate_ticket",
+      "type": "python",
+      "action": "notify_on_call",
+      "next": "done"
+    },
+    {
+      "id": "draft_reply",
+      "type": "python",
+      "action": "compose_reply",
+      "next": "done"
+    }
+  ]
+}

--- a/ui/src/assets/workflows/examples/support-ticket-triage.toml
+++ b/ui/src/assets/workflows/examples/support-ticket-triage.toml
@@ -1,0 +1,31 @@
+id = "support_ticket_triage"
+name = "Support Ticket Triage"
+version = "1.0.0"
+start_at = "collect_ticket"
+
+[[steps]]
+id = "collect_ticket"
+type = "python"
+action = "collect_ticket"
+next = "classify_priority"
+
+[[steps]]
+id = "classify_priority"
+type = "python"
+action = "classify_priority"
+
+[steps.next]
+urgent = "escalate_ticket"
+default = "draft_reply"
+
+[[steps]]
+id = "escalate_ticket"
+type = "python"
+action = "notify_on_call"
+next = "done"
+
+[[steps]]
+id = "draft_reply"
+type = "python"
+action = "compose_reply"
+next = "done"

--- a/ui/src/assets/workflows/examples/support-ticket-triage.yaml
+++ b/ui/src/assets/workflows/examples/support-ticket-triage.yaml
@@ -1,0 +1,23 @@
+id: support_ticket_triage
+name: Support Ticket Triage
+version: 1.0.0
+start_at: collect_ticket
+steps:
+  - id: collect_ticket
+    type: python
+    action: collect_ticket
+    next: classify_priority
+  - id: classify_priority
+    type: python
+    action: classify_priority
+    next:
+      urgent: escalate_ticket
+      default: draft_reply
+  - id: escalate_ticket
+    type: python
+    action: notify_on_call
+    next: done
+  - id: draft_reply
+    type: python
+    action: compose_reply
+    next: done


### PR DESCRIPTION
### Motivation
- Provide a visible, persisted example workflow inside the Workflow Studio so operators can inspect a concrete flow while the visual editor is still in development.
- Surface import/export formats (YAML, JSON, TOML) for validation and to make example workflows immediately consumable by the UI and runtime.

### Description
- Added three example workflow assets under `ui/src/assets/workflows/examples/` in `support-ticket-triage.yaml`, `support-ticket-triage.json`, and `support-ticket-triage.toml`.
- Enhanced the Workflow Studio page component to include an in-app example browser with format tabs, loading/error states, live content preview, and a raw-file link, implemented via `HttpClient` in `workflow-studio-page.component.ts`.
- Added supporting markup and styles for the example viewer in `workflow-studio-page.component.html` and `workflow-studio-page.component.css` to preserve the existing studio layout and add tabs/preview UI.
- Expanded unit tests in `workflow-studio-page.component.spec.ts` to validate initial YAML loading and JSON-format switching via HTTP testing utilities.

### Testing
- Built the UI with `cd ui && npm run build -- --configuration development`, and the build completed successfully.
- Attempted to run the studio component unit test with `cd ui && npm test -- --watch=false --include src/app/features/workflow-studio/workflow-studio-page.component.spec.ts`, but the test run failed in this environment due to a missing Chrome binary reported by Karma, preventing headless browser execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b1ff247c83338d6935c4acf59117)

## Summary by Sourcery

Add a saved workflow example browser to the Workflow Studio page so operators can view a persisted support ticket triage flow in multiple formats.

New Features:
- Introduce an in-app example viewer on the Workflow Studio canvas that loads a persisted support ticket triage workflow in YAML, JSON, and TOML formats with format switching and error handling.

Tests:
- Extend Workflow Studio component tests to verify the example workflow is rendered initially and that selecting the JSON tab triggers the correct HTTP request and display.