### PR TITLE
Add daemon lifecycle controls to run_app.sh for API mode

### DIFF
--- a/BITACORA.md
+++ b/BITACORA.md
@@ -328,6 +328,11 @@ Each entry should use:
 **Entry:** Implemented issue `#105` on `fix/issue-105-workflow-loader-yaml-guard` after fast-forwarding local `master` to `origin/master` and branching from the updated base. Hardened `WorkflowLoader` to reject empty or non-mapping YAML roots with a clear filepath-specific `ValueError`, added loader tests for empty/list/scalar YAML inputs, and revalidated with `bash scripts/run_tests.sh`: `69 passed`, `100.00%` coverage.
 
 ---
+**Timestamp:** 2026-04-10 12:35 CEST
+**Author:** Codex
+**Entry:** Hardened PR `#172` on `codex/update-application-run-script-for-daemon-mode` by fixing `run_app.sh` daemon argument validation, enforcing `--api` explicitly in daemon mode, forwarding parsed backend flags into the detached API start path, and switching daemon PID/log files to host-and-port-specific defaults with environment overrides. Updated `scripts/run_backend.sh` to `exec` the Python CLI so daemon stop targets the real backend process instead of an intermediate shell wrapper. Aligned `README.md`, `STATUS.md`, and `TESTING.md` with the new repo-root API daemon lifecycle commands.
+
+---
 **Timestamp:** 2026-03-27 16:09 UTC
 **Author:** Codex
 **Entry:** Applied the substantive PR `#126` review fixes on the run-store branch without deleting prior review context or comments. Hardened `LocalJSONRunStore` against path traversal by validating `run_id`-derived file paths, introduced a typed `RunStatus` enum, narrowed exception handling to concrete parse/validation/file-operation failures, wrapped save-time write failures in an explicit runtime error, and expanded tests for invalid statuses, invalid stored records, path traversal rejection, and write failures. Verified with `bash scripts/run_tests.sh`: `64 passed`, `100.00%` coverage.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ Start the local API server:
 bash scripts/run_backend.sh --api --host 127.0.0.1 --port 8000
 ```
 
+Manage the local API server through the repo-root launcher:
+
+```bash
+bash run_app.sh --api --daemon start
+bash run_app.sh --api --daemon status
+bash run_app.sh --api --daemon stop
+```
+
+Daemon mode stores host/port-specific PID and log files in the repo root by default.
+You can override those paths with `MAGNETAR_API_PID_FILE` and `MAGNETAR_API_LOG_FILE`.
+
 ### UI Only
 
 Mock mode:

--- a/STATUS.md
+++ b/STATUS.md
@@ -9,14 +9,15 @@ What is real today:
 - A Python workflow engine can load a YAML workflow, execute registered steps, evaluate conditional routing, and return a structured `RunContext`.
 - A bootstrap path can prepare the local Python runtime and install the dependencies required by the current proof-of-concept slice.
 - A one-command local launcher exists: `bash run_app.sh`.
+- The local API server can now also be managed through repo-root daemon lifecycle commands.
 - An example workflow, `email_triage`, runs end to end and produces deterministic JSON output.
 - CI and local test execution enforce `100%` coverage for the implemented backend and SDK scope.
 - The Angular UI tier now also enforces `100%` coverage for statements, branches, functions, and lines.
 
 What is not real yet:
 
-- There is no long-running backend service.
-- There is no HTTP API for job submission or run inspection.
+- There is no production-grade long-running backend service with persistence, queueing, or worker management.
+- There is no complete HTTP API for job submission or run inspection.
 - A first Angular web shell exists in mock mode (`ui/`), upgraded to Angular 21, but it is not API-backed yet.
 - There is no desktop UI.
 - There is no operator dashboard, queue manager, or persistent run history.
@@ -45,13 +46,14 @@ the repository will:
 4. print the resulting workflow state as JSON
 5. exit
 
-That means the current user experience is batch-style CLI execution, not an interactive app session.
+That means the current user experience is primarily batch-style CLI execution, with a minimal local API mode available for development and validation.
 
 ## What A User Can Do Right Now
 
 - Run the current proof-of-concept workflow engine locally from the repository root.
 - Execute the built-in example workflow and inspect the final workflow state.
 - Point the CLI at another compatible workflow YAML file.
+- Start, stop, and inspect the status of the minimal local API server from the repository root.
 - Inspect how the engine resolves steps, branching, evaluator logic, and context aggregation.
 - Validate changes through the local test path and CI-oriented scripts.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -87,12 +87,16 @@ To validate the product locally from the repository root:
 
 ```bash
 bash run_app.sh
+bash run_app.sh --api --daemon start --port 8010
+bash run_app.sh --api --daemon status --port 8010
+bash run_app.sh --api --daemon stop --port 8010
 bash scripts/run_tests.sh
 ```
 
 These commands validate both the visible surface (the CLI) and the internal correctness (the engine tests):
 
 - `run_app.sh` proves the backend can bootstrap and execute the example workflow
+- `run_app.sh --api --daemon ...` proves the repo-root launcher can manage the minimal API lifecycle with explicit local bind controls
 - `scripts/run_tests.sh` proves the implemented backend, SDK, and UI scopes still satisfy the enforced coverage contracts
 
 ## Bug Reporting Process

--- a/run_app.sh
+++ b/run_app.sh
@@ -4,6 +4,155 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BOOTSTRAP_SCRIPT="${ROOT_DIR}/scripts/bootstrap_python.sh"
 RUN_SCRIPT="${ROOT_DIR}/scripts/run_backend.sh"
+PID_FILE="${ROOT_DIR}/.magnetar_api.pid"
+LOG_FILE="${ROOT_DIR}/.magnetar_api.log"
+
+MODE="run"
+DAEMON=0
+HOST="127.0.0.1"
+PORT="8000"
+FORWARD_ARGS=()
+
+usage() {
+    cat <<USAGE
+Usage:
+  bash run_app.sh [--workflow <path>] [--format summary|json]
+  bash run_app.sh --api [--host <host>] [--port <port>]
+  bash run_app.sh --api --daemon start [--host <host>] [--port <port>]
+  bash run_app.sh --api --daemon stop
+  bash run_app.sh --api --daemon status
+
+Notes:
+  - Default mode runs the one-shot workflow execution path.
+  - Daemon mode is only supported with --api.
+USAGE
+}
+
+is_pid_running() {
+    local pid="$1"
+    kill -0 "${pid}" 2>/dev/null
+}
+
+start_daemon() {
+    if [ -f "${PID_FILE}" ]; then
+        local existing_pid
+        existing_pid="$(cat "${PID_FILE}")"
+        if [ -n "${existing_pid}" ] && is_pid_running "${existing_pid}"; then
+            echo "MagnetarPrometheus API daemon is already running with PID ${existing_pid}."
+            echo "Logs: ${LOG_FILE}"
+            return 0
+        fi
+        rm -f "${PID_FILE}"
+    fi
+
+    echo "Starting MagnetarPrometheus API daemon on http://${HOST}:${PORT} ..."
+    nohup bash "${RUN_SCRIPT}" --api --host "${HOST}" --port "${PORT}" >"${LOG_FILE}" 2>&1 &
+    local daemon_pid=$!
+    echo "${daemon_pid}" > "${PID_FILE}"
+    echo "MagnetarPrometheus API daemon started with PID ${daemon_pid}."
+    echo "Stop it with: bash run_app.sh --api --daemon stop"
+    echo "Logs: ${LOG_FILE}"
+}
+
+stop_daemon() {
+    if [ ! -f "${PID_FILE}" ]; then
+        echo "No PID file found at ${PID_FILE}. Daemon does not appear to be running."
+        return 0
+    fi
+
+    local daemon_pid
+    daemon_pid="$(cat "${PID_FILE}")"
+
+    if [ -z "${daemon_pid}" ]; then
+        echo "PID file is empty. Cleaning up stale PID file."
+        rm -f "${PID_FILE}"
+        return 0
+    fi
+
+    if ! is_pid_running "${daemon_pid}"; then
+        echo "No running process found for PID ${daemon_pid}. Cleaning up stale PID file."
+        rm -f "${PID_FILE}"
+        return 0
+    fi
+
+    echo "Stopping MagnetarPrometheus API daemon PID ${daemon_pid} ..."
+    kill "${daemon_pid}" 2>/dev/null || true
+
+    for _ in {1..20}; do
+        if ! is_pid_running "${daemon_pid}"; then
+            break
+        fi
+        sleep 0.25
+    done
+
+    if is_pid_running "${daemon_pid}"; then
+        echo "PID ${daemon_pid} did not stop with SIGTERM; sending SIGKILL."
+        kill -9 "${daemon_pid}" 2>/dev/null || true
+    fi
+
+    rm -f "${PID_FILE}"
+    echo "MagnetarPrometheus API daemon stopped."
+}
+
+daemon_status() {
+    if [ ! -f "${PID_FILE}" ]; then
+        echo "MagnetarPrometheus API daemon is not running."
+        return 1
+    fi
+
+    local daemon_pid
+    daemon_pid="$(cat "${PID_FILE}")"
+
+    if [ -n "${daemon_pid}" ] && is_pid_running "${daemon_pid}"; then
+        echo "MagnetarPrometheus API daemon is running with PID ${daemon_pid}."
+        echo "Logs: ${LOG_FILE}"
+        return 0
+    fi
+
+    echo "PID file exists but daemon is not running."
+    return 1
+}
+
+while (($#)); do
+    case "$1" in
+        --api)
+            MODE="api"
+            FORWARD_ARGS+=("$1")
+            shift
+            ;;
+        --daemon)
+            DAEMON=1
+            shift
+            ;;
+        start|stop|status)
+            if [ "${DAEMON}" -eq 1 ]; then
+                MODE="$1"
+                shift
+            else
+                FORWARD_ARGS+=("$1")
+                shift
+            fi
+            ;;
+        --host)
+            HOST="${2:-}"
+            FORWARD_ARGS+=("$1" "${HOST}")
+            shift 2
+            ;;
+        --port)
+            PORT="${2:-}"
+            FORWARD_ARGS+=("$1" "${PORT}")
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            FORWARD_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
 
 echo "Starting MagnetarPrometheus..."
 
@@ -17,7 +166,39 @@ if [ ! -x "${RUN_SCRIPT}" ]; then
     exit 1
 fi
 
-bash "${BOOTSTRAP_SCRIPT}"
+if ! { [ "${DAEMON}" -eq 1 ] && [[ "${MODE}" == "stop" || "${MODE}" == "status" ]]; }; then
+    bash "${BOOTSTRAP_SCRIPT}"
+fi
+
+if [ "${DAEMON}" -eq 1 ] && [ "${MODE}" != "api" ] && [ "${MODE}" != "start" ] && [ "${MODE}" != "stop" ] && [ "${MODE}" != "status" ]; then
+    echo "Daemon mode requires --api and one of: start, stop, status"
+    exit 1
+fi
+
+if [ "${DAEMON}" -eq 1 ]; then
+    if [[ "${MODE}" != "start" && "${MODE}" != "stop" && "${MODE}" != "status" ]]; then
+        echo "Daemon mode requires one of: start, stop, status"
+        exit 1
+    fi
+
+    case "${MODE}" in
+        start)
+            start_daemon
+            ;;
+        stop)
+            stop_daemon
+            ;;
+        status)
+            daemon_status
+            ;;
+    esac
+    exit 0
+fi
+
 echo
-echo "Launching example workflow..."
-bash "${RUN_SCRIPT}" "$@"
+if [ "${MODE}" = "api" ]; then
+    echo "Launching backend API in foreground mode..."
+else
+    echo "Launching example workflow..."
+fi
+bash "${RUN_SCRIPT}" "${FORWARD_ARGS[@]}"

--- a/run_app.sh
+++ b/run_app.sh
@@ -4,11 +4,12 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BOOTSTRAP_SCRIPT="${ROOT_DIR}/scripts/bootstrap_python.sh"
 RUN_SCRIPT="${ROOT_DIR}/scripts/run_backend.sh"
-PID_FILE="${ROOT_DIR}/.magnetar_api.pid"
-LOG_FILE="${ROOT_DIR}/.magnetar_api.log"
+PID_FILE="${MAGNETAR_API_PID_FILE:-}"
+LOG_FILE="${MAGNETAR_API_LOG_FILE:-}"
 
 MODE="run"
 DAEMON=0
+API_MODE=0
 HOST="127.0.0.1"
 PORT="8000"
 FORWARD_ARGS=()
@@ -25,12 +26,36 @@ Usage:
 Notes:
   - Default mode runs the one-shot workflow execution path.
   - Daemon mode is only supported with --api.
+  - Daemon PID/log files default to host/port-specific filenames unless
+    MAGNETAR_API_PID_FILE or MAGNETAR_API_LOG_FILE override them.
 USAGE
 }
 
 is_pid_running() {
     local pid="$1"
     kill -0 "${pid}" 2>/dev/null
+}
+
+require_option_value() {
+    local option_name="$1"
+
+    if [ "$#" -lt 2 ] || [ -z "${2:-}" ] || [[ "${2:-}" == --* ]]; then
+        echo "Error: ${option_name} requires a value."
+        exit 1
+    fi
+}
+
+set_daemon_file_paths() {
+    local host_slug
+    host_slug="$(printf '%s' "${HOST}" | tr -c 'A-Za-z0-9._-' '_')"
+
+    if [ -z "${PID_FILE}" ]; then
+        PID_FILE="${ROOT_DIR}/.magnetar_api_${host_slug}_${PORT}.pid"
+    fi
+
+    if [ -z "${LOG_FILE}" ]; then
+        LOG_FILE="${ROOT_DIR}/.magnetar_api_${host_slug}_${PORT}.log"
+    fi
 }
 
 start_daemon() {
@@ -46,7 +71,7 @@ start_daemon() {
     fi
 
     echo "Starting MagnetarPrometheus API daemon on http://${HOST}:${PORT} ..."
-    nohup bash "${RUN_SCRIPT}" --api --host "${HOST}" --port "${PORT}" >"${LOG_FILE}" 2>&1 &
+    nohup bash "${RUN_SCRIPT}" "${FORWARD_ARGS[@]}" >"${LOG_FILE}" 2>&1 &
     local daemon_pid=$!
     echo "${daemon_pid}" > "${PID_FILE}"
     echo "MagnetarPrometheus API daemon started with PID ${daemon_pid}."
@@ -117,6 +142,7 @@ while (($#)); do
     case "$1" in
         --api)
             MODE="api"
+            API_MODE=1
             FORWARD_ARGS+=("$1")
             shift
             ;;
@@ -134,12 +160,14 @@ while (($#)); do
             fi
             ;;
         --host)
-            HOST="${2:-}"
+            require_option_value "$@"
+            HOST="$2"
             FORWARD_ARGS+=("$1" "${HOST}")
             shift 2
             ;;
         --port)
-            PORT="${2:-}"
+            require_option_value "$@"
+            PORT="$2"
             FORWARD_ARGS+=("$1" "${PORT}")
             shift 2
             ;;
@@ -154,6 +182,8 @@ while (($#)); do
     esac
 done
 
+set_daemon_file_paths
+
 echo "Starting MagnetarPrometheus..."
 
 if [ ! -x "${BOOTSTRAP_SCRIPT}" ]; then
@@ -166,11 +196,7 @@ if [ ! -x "${RUN_SCRIPT}" ]; then
     exit 1
 fi
 
-if ! { [ "${DAEMON}" -eq 1 ] && [[ "${MODE}" == "stop" || "${MODE}" == "status" ]]; }; then
-    bash "${BOOTSTRAP_SCRIPT}"
-fi
-
-if [ "${DAEMON}" -eq 1 ] && [ "${MODE}" != "api" ] && [ "${MODE}" != "start" ] && [ "${MODE}" != "stop" ] && [ "${MODE}" != "status" ]; then
+if [ "${DAEMON}" -eq 1 ] && [ "${API_MODE}" -ne 1 ]; then
     echo "Daemon mode requires --api and one of: start, stop, status"
     exit 1
 fi
@@ -180,7 +206,13 @@ if [ "${DAEMON}" -eq 1 ]; then
         echo "Daemon mode requires one of: start, stop, status"
         exit 1
     fi
+fi
 
+if ! { [ "${DAEMON}" -eq 1 ] && [[ "${MODE}" == "stop" || "${MODE}" == "status" ]]; }; then
+    bash "${BOOTSTRAP_SCRIPT}"
+fi
+
+if [ "${DAEMON}" -eq 1 ]; then
     case "${MODE}" in
         start)
             start_daemon

--- a/scripts/run_backend.sh
+++ b/scripts/run_backend.sh
@@ -17,4 +17,4 @@ source "${VENV_ACTIVATE}"
 # The runtime shell wrapper stays intentionally thin.
 # The PoC behavior should be reproducible from a clean checkout without
 # requiring the caller to manually activate a virtual environment first.
-PYTHONPATH="${ROOT_DIR}/sdk/python/src:${ROOT_DIR}/backend/src" python -m magnetar_prometheus.cli "$@"
+exec env PYTHONPATH="${ROOT_DIR}/sdk/python/src:${ROOT_DIR}/backend/src" python -m magnetar_prometheus.cli "$@"


### PR DESCRIPTION
### Motivation
- Operators need a way to run the API backend as a background/managed daemon and stop it later from the same script instead of the backend being tied to the invoking terminal.
- The existing `run_app.sh` only launched a one-shot workflow or foreground API and did not provide a scripted start/stop/status lifecycle for long-lived API runs.

### Description
- Extended `run_app.sh` with argument parsing and usage help so `--api` can run in foreground or as a managed daemon with `--daemon` and `start|stop|status` commands.
- Implemented daemon lifecycle primitives: `start` launches the API with `nohup` and writes a PID file (`.magnetar_api.pid`) and log file (`.magnetar_api.log`), `stop` attempts graceful shutdown via `SIGTERM` with a `SIGKILL` fallback, and `status` reports running state.
- Avoided performing the heavy Python bootstrap for `stop` and `status` operations so those checks remain fast and usable even when dependency installation is unavailable.
- Preserved existing behavior for one-shot workflow runs and foreground `--api` runs and forwarded other CLI args through to the backend run script.

### Testing
- Ran shell syntax check with `bash -n run_app.sh` which succeeded.
- Verified `bash run_app.sh --help` displays the updated usage text successfully.
- Attempted an end-to-end daemon flow (`--daemon start` then `status`, `curl /health`, then `--daemon stop`) but the environment failed during the bootstrap dependency install step (proxy/package index access blocked), so the full runtime start/stop/health validation could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b27dace48333bd49b99676be321a)

## Summary by Sourcery

Add managed daemon lifecycle controls to run_app.sh for the API backend while preserving existing workflow and foreground API behavior.

New Features:
- Introduce API daemon start/stop/status commands with PID and log file management in run_app.sh.
- Add CLI argument parsing and help text to support daemon mode, host/port configuration, and forwarding of remaining arguments to the backend runner.

Enhancements:
- Skip Python bootstrap for daemon stop/status operations to keep lifecycle checks fast and independent of runtime dependencies.