### PR TITLE
Introduce generic backend plugin runtime with bundled example plugins and tests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -28,6 +28,7 @@ Current implemented slice:
 - execution engine
 - evaluator
 - executor routing
+- plugin contract loading and step-capability registration
 - context accumulation
 - shared SDK models and schema documents
 
@@ -54,6 +55,7 @@ Responsibility:
 - workflow loading and validation
 - orchestration engine
 - executor routing
+- plugin contract loading and step-capability registration
 - runtime context management
 - logging and persistence
 - runtime bootstrap and dependency readiness checks

--- a/BITACORA.md
+++ b/BITACORA.md
@@ -38,6 +38,11 @@ Each entry should use:
 ## Entries
 
 ---
+**Timestamp:** 2026-04-10 14:15 CEST
+**Author:** Gemini CLI
+**Entry:** Restored 100% code coverage for the backend on branch `codex/plan-plugin-architecture-for-extensibility` (PR `#175`). Added missing test cases in `backend/tests/test_plugins.py` to cover `PluginManager` duplicate registration, entrypoint discovery (via monkeypatching), and step ownership diagnostics. Verified all 118 backend tests pass with 100.00% total coverage.
+
+---
 **Timestamp:** 2026-04-10 13:30 CEST
 **Author:** Gemini CLI
 **Entry:** Resolved UI code contract and build failures on `codex/add-functionality-to-save-and-load-workflows` to unblock PR `#176`. Added explicit `public` access modifiers to `ngOnInit` and `ngOnDestroy` in `WorkflowStudioPageComponent` as required by the repository's UI contract guard. Increased the `anyComponentStyle` budget in `ui/angular.json` to 10kb/20kb to accommodate the redesigned Workflow Studio styles. Verified the fixes by running the UI test tier: contract and build checks now pass. Updated PR `#176` with labels (`✨ feature`, `🎨 ux`, `🧪 tests`, `♻️ code quality`, `area:ui`, `Level 3 (Visual Model)`) and linked it to issue `#7`.

--- a/BITACORA.md
+++ b/BITACORA.md
@@ -38,6 +38,11 @@ Each entry should use:
 ## Entries
 
 ---
+**Timestamp:** 2026-04-10 15:55 CEST
+**Author:** Gemini CLI
+**Entry:** Achieved 100.00% code coverage for the UI slice on branch `codex/plan-plugin-architecture-for-extensibility`. Expanded `workflow-studio-page.component.spec.ts` with comprehensive unit tests covering all remaining statements, branches, and edge cases in `WorkflowStudioPageComponent`. Specifically addressed `fakeAsync` timing for `runWorkflow`, defensive `localStorage` access paths, project loading fallbacks, and component lifecycle cleanup. Verified all 102 UI tests pass with full statement, branch, function, and line coverage.
+
+---
 **Timestamp:** 2026-04-10 14:45 CEST
 **Author:** Gemini CLI
 **Entry:** Completed review follow-up for PR `#175`. Extracted `build_plugin_manager` to a shared bootstrap module to remove duplication across the CLI and API server. Hardened `PluginManager.discover_entrypoint_plugins` with robust error handling, type checks, and logging. Standardized "step-capability" hyphenation across `README.md`, `ARCHITECTURE.md`, and `STATUS.md`. Simplified the backward-compatible `register_all_example_steps` helper. All 118 backend tests pass with 100.00% total coverage.

--- a/BITACORA.md
+++ b/BITACORA.md
@@ -38,9 +38,9 @@ Each entry should use:
 ## Entries
 
 ---
-**Timestamp:** 2026-04-10 15:55 CEST
+**Timestamp:** 2026-04-10 16:15 CEST
 **Author:** Gemini CLI
-**Entry:** Achieved 100.00% code coverage for the UI slice on branch `codex/plan-plugin-architecture-for-extensibility`. Expanded `workflow-studio-page.component.spec.ts` with comprehensive unit tests covering all remaining statements, branches, and edge cases in `WorkflowStudioPageComponent`. Specifically addressed `fakeAsync` timing for `runWorkflow`, defensive `localStorage` access paths, project loading fallbacks, and component lifecycle cleanup. Verified all 102 UI tests pass with full statement, branch, function, and line coverage.
+**Entry:** Finalized PR `#175` hardening pass. Achieved 100.00% code coverage for both Backend and UI slices (fixing the prior Chrome Headless coverage failure). Extracted a shared `build_plugin_manager` bootstrap helper to remove duplication, hardened plugin discovery with defensive error handling and logging, and standardized hyphenation in core documentation. Verified all 118 backend and 102 UI tests pass with full branch and statement coverage. Updated PR description to reflect the improved technical baseline.
 
 ---
 **Timestamp:** 2026-04-10 14:45 CEST

--- a/BITACORA.md
+++ b/BITACORA.md
@@ -38,6 +38,11 @@ Each entry should use:
 ## Entries
 
 ---
+**Timestamp:** 2026-04-10 14:45 CEST
+**Author:** Gemini CLI
+**Entry:** Completed review follow-up for PR `#175`. Extracted `build_plugin_manager` to a shared bootstrap module to remove duplication across the CLI and API server. Hardened `PluginManager.discover_entrypoint_plugins` with robust error handling, type checks, and logging. Standardized "step-capability" hyphenation across `README.md`, `ARCHITECTURE.md`, and `STATUS.md`. Simplified the backward-compatible `register_all_example_steps` helper. All 118 backend tests pass with 100.00% total coverage.
+
+---
 **Timestamp:** 2026-04-10 14:15 CEST
 **Author:** Gemini CLI
 **Entry:** Restored 100% code coverage for the backend on branch `codex/plan-plugin-architecture-for-extensibility` (PR `#175`). Added missing test cases in `backend/tests/test_plugins.py` to cover `PluginManager` duplicate registration, entrypoint discovery (via monkeypatching), and step ownership diagnostics. Verified all 118 backend tests pass with 100.00% total coverage.

--- a/PLAN.md
+++ b/PLAN.md
@@ -52,6 +52,7 @@ Execution strategy for upcoming slices:
 | `task-112` | `ms-01` | Define Bitacora retention and archival flow | Edward + AI | 3 | 14 | `planned` | Move `BITACORA.md` entries older than 2 days into durable GitHub surfaces such as Discussions and the wiki so the repo logbook stays current and scannable. |
 | `task-113` | `ms-04` | Implement HTTP API and local persistence for job submission | Unassigned | 5 | 24 | `planned` | User increment: A user can start a backend service, submit workflow runs via HTTP rather than CLI, and inspect run outcomes. |
 | `task-114` | `ms-05` | Develop a minimal web UI for observing workflows | Unassigned | 5 | 24 | `planned` | User increment: A user can open a browser and view persistent run history and job statuses without reading raw JSON. |
+| `task-115` | `ms-04` | Introduce generic backend plugin runtime for step capability extension | Edward + AI | 5 | 24 | `done` | Added typed plugin contracts, a plugin manager, bundled example plugin manifest, and startup wiring through plugin registration so new capabilities can be added without core-engine rewrites. |
 
 ## Preserved Historical Task Records
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ If you are trying to understand the product, start with this README and the runn
 
 ## Plugin-Ready Runtime (New)
 
-MagnetarPrometheus now includes a generic backend plugin layer for step capability extension.
+MagnetarPrometheus now includes a generic backend plugin layer for step-capability extension.
 
 What this enables today:
 

--- a/README.md
+++ b/README.md
@@ -170,3 +170,22 @@ The repository also carries governance and planning documents, but those are sup
 - [RULES.md](/Users/edwardflores/Projects/Development/MagnetarPrometheus/RULES.md)
 
 If you are trying to understand the product, start with this README and the runnable commands above. If you are trying to understand repository governance, then move into the planning and rules documents.
+
+
+## Plugin-Ready Runtime (New)
+
+MagnetarPrometheus now includes a generic backend plugin layer for step capability extension.
+
+What this enables today:
+
+- bundled example capabilities are loaded through a plugin manager instead of hard-coded wiring
+- plugin contracts are typed (manifest + runtime handlers) and API-version checked
+- the runtime rejects conflicting step ownership early for deterministic startup
+
+What remains intentionally future-scoped:
+
+- plugin signing and trust policy controls
+- remote plugin distribution/catalog flows
+- richer UI/plugin capability metadata surfaces
+
+This preserves the current local developer experience while opening a clear path for adding new capabilities without repeatedly modifying core engine wiring.

--- a/STATUS.md
+++ b/STATUS.md
@@ -97,6 +97,7 @@ The tracked planning baseline is marked complete for the currently defined `44 /
 - Serial workflow execution with step-by-step context accumulation.
 - Conditional routing through the evaluator path.
 - Step registration and Python executor routing.
+- Plugin-manager-based step capability loading with bundled core example plugin metadata.
 - Structured context/result output for completed runs.
 - Example email-triage module with manifest, workflow, and step handlers.
 - Runtime bootstrap with dependency checking and policy-driven install behavior.
@@ -110,7 +111,7 @@ The tracked planning baseline is marked complete for the currently defined `44 /
 - There is no scheduler, queue, or worker pool.
 - Workflow definitions are still authored manually rather than through a product interface.
 - The UI graph schema is a contract artifact only; it is not backed by a functioning editor.
-- The current module surface is demonstrative, not yet a mature plug-and-play module system.
+- A first generic backend plugin runtime now exists for step-capability extension, but policy controls, signing, and remote distribution are still future work.
 - Release automation currently produces metadata/version-stamp outputs, not a complete distribution pipeline.
 
 ## Immediate Delivery Focus

--- a/STATUS.md
+++ b/STATUS.md
@@ -97,7 +97,7 @@ The tracked planning baseline is marked complete for the currently defined `44 /
 - Serial workflow execution with step-by-step context accumulation.
 - Conditional routing through the evaluator path.
 - Step registration and Python executor routing.
-- Plugin-manager-based step capability loading with bundled core example plugin metadata.
+- Plugin-manager-based step-capability loading with bundled core example plugin metadata.
 - Structured context/result output for completed runs.
 - Example email-triage module with manifest, workflow, and step handlers.
 - Runtime bootstrap with dependency checking and policy-driven install behavior.

--- a/backend/src/magnetar_prometheus/api/server.py
+++ b/backend/src/magnetar_prometheus/api/server.py
@@ -33,8 +33,7 @@ from magnetar_prometheus.core.engine import Engine
 from magnetar_prometheus.core.executor_router import ExecutorRouter
 from magnetar_prometheus.core.workflow_loader import WorkflowLoader
 from magnetar_prometheus.executors.python_executor import PythonExecutor
-from magnetar_prometheus.modules.example_registry import get_builtin_plugins
-from magnetar_prometheus.plugins.manager import PluginManager
+from magnetar_prometheus.plugins.bootstrap import build_plugin_manager
 from magnetar_prometheus.registry.step_registry import StepRegistry
 
 logger = logging.getLogger(__name__)
@@ -85,9 +84,7 @@ def _build_example_runtime() -> tuple[Path, object, Engine]:
     workflow = loader.load_workflow(str(workflow_path))
 
     registry = StepRegistry()
-    plugin_manager = PluginManager()
-    plugin_manager.register_many(get_builtin_plugins())
-    plugin_manager.register_into(registry)
+    build_plugin_manager(registry)
 
     executor = PythonExecutor(registry)
     router = ExecutorRouter()

--- a/backend/src/magnetar_prometheus/api/server.py
+++ b/backend/src/magnetar_prometheus/api/server.py
@@ -33,7 +33,8 @@ from magnetar_prometheus.core.engine import Engine
 from magnetar_prometheus.core.executor_router import ExecutorRouter
 from magnetar_prometheus.core.workflow_loader import WorkflowLoader
 from magnetar_prometheus.executors.python_executor import PythonExecutor
-from magnetar_prometheus.modules.example_registry import register_all_example_steps
+from magnetar_prometheus.modules.example_registry import get_builtin_plugins
+from magnetar_prometheus.plugins.manager import PluginManager
 from magnetar_prometheus.registry.step_registry import StepRegistry
 
 logger = logging.getLogger(__name__)
@@ -84,7 +85,9 @@ def _build_example_runtime() -> tuple[Path, object, Engine]:
     workflow = loader.load_workflow(str(workflow_path))
 
     registry = StepRegistry()
-    register_all_example_steps(registry)
+    plugin_manager = PluginManager()
+    plugin_manager.register_many(get_builtin_plugins())
+    plugin_manager.register_into(registry)
 
     executor = PythonExecutor(registry)
     router = ExecutorRouter()

--- a/backend/src/magnetar_prometheus/cli.py
+++ b/backend/src/magnetar_prometheus/cli.py
@@ -40,7 +40,8 @@ from magnetar_prometheus.core.engine import Engine
 from magnetar_prometheus.core.executor_router import ExecutorRouter
 from magnetar_prometheus.core.workflow_loader import WorkflowLoader
 from magnetar_prometheus.executors.python_executor import PythonExecutor
-from magnetar_prometheus.modules.example_registry import register_all_example_steps
+from magnetar_prometheus.modules.example_registry import get_builtin_plugins
+from magnetar_prometheus.plugins.manager import PluginManager
 from magnetar_prometheus.registry.step_registry import StepRegistry
 
 
@@ -183,7 +184,9 @@ def main():
         sys.exit(1)
 
     registry = StepRegistry()
-    register_all_example_steps(registry)
+    plugin_manager = PluginManager()
+    plugin_manager.register_many(get_builtin_plugins())
+    plugin_manager.register_into(registry)
 
     executor = PythonExecutor(registry)
     router = ExecutorRouter()

--- a/backend/src/magnetar_prometheus/cli.py
+++ b/backend/src/magnetar_prometheus/cli.py
@@ -40,8 +40,7 @@ from magnetar_prometheus.core.engine import Engine
 from magnetar_prometheus.core.executor_router import ExecutorRouter
 from magnetar_prometheus.core.workflow_loader import WorkflowLoader
 from magnetar_prometheus.executors.python_executor import PythonExecutor
-from magnetar_prometheus.modules.example_registry import get_builtin_plugins
-from magnetar_prometheus.plugins.manager import PluginManager
+from magnetar_prometheus.plugins.bootstrap import build_plugin_manager
 from magnetar_prometheus.registry.step_registry import StepRegistry
 
 
@@ -184,9 +183,7 @@ def main():
         sys.exit(1)
 
     registry = StepRegistry()
-    plugin_manager = PluginManager()
-    plugin_manager.register_many(get_builtin_plugins())
-    plugin_manager.register_into(registry)
+    build_plugin_manager(registry)
 
     executor = PythonExecutor(registry)
     router = ExecutorRouter()

--- a/backend/src/magnetar_prometheus/modules/example_registry.py
+++ b/backend/src/magnetar_prometheus/modules/example_registry.py
@@ -22,8 +22,8 @@ from magnetar_prometheus.modules.error_module.steps import start_error, trigger_
 from magnetar_prometheus.modules.http_module.steps import http_get, json_parse
 from magnetar_prometheus.modules.linear_module.steps import process_linear, start_linear
 from magnetar_prometheus.modules.math_module.steps import math_add, math_multiply
-from magnetar_prometheus.plugins.manager import PluginManager
 from magnetar_prometheus.plugins.models import PluginManifest, PluginRuntime
+from magnetar_prometheus.registry.step_registry import StepRegistry
 
 
 def get_builtin_plugins() -> list[PluginRuntime]:
@@ -73,8 +73,11 @@ def get_builtin_plugins() -> list[PluginRuntime]:
     return [core_plugin]
 
 
-def register_all_example_steps(registry) -> None:
-    """Backward-compatible helper that registers every bundled example step."""
-    plugin_manager = PluginManager()
-    plugin_manager.register_many(get_builtin_plugins())
-    plugin_manager.register_into(registry)
+def register_all_example_steps(registry: StepRegistry) -> None:
+    """Backward-compatible helper that registers every bundled example step.
+
+    This stays a direct, easy-to-read helper and does not depend on PluginManager.
+    """
+    for plugin in get_builtin_plugins():
+        for step_type, handler in plugin.step_handlers.items():
+            registry.register(step_type, handler)

--- a/backend/src/magnetar_prometheus/modules/example_registry.py
+++ b/backend/src/magnetar_prometheus/modules/example_registry.py
@@ -1,33 +1,80 @@
-"""Application-level registration for bundled example workflow modules.
+"""Application-level plugin assembly for bundled example workflow modules.
 
 Why this file exists in this form:
 
-- The repository currently ships a handful of small example workflow modules that are useful
-  together in the CLI and API demonstration surfaces, but those modules should not import one
-  another just to become runnable.
-- Earlier branch work temporarily registered ``linear_module`` and ``error_module`` from
-  inside ``email_module`` because the application entrypoints only had one obvious seed
-  function. That worked operationally, but it created the wrong dependency direction by making
-  one example module responsible for wiring unrelated examples.
-- This file is the narrow application-level fix for that problem. The individual modules stay
-  responsible for their own handlers, while the CLI and API can import one explicit helper
-  when they want the full bundled example surface.
-- The helper stays intentionally small. It is not a general plugin system or dynamic module
-  discovery layer yet; it is only the central registration point for the example modules that
-  the repository currently uses for demonstration and testing.
+- The repository ships several deterministic example modules used across CLI, API, and tests.
+  They should be installable as a coherent default plugin bundle without forcing each module
+  to import unrelated siblings.
+- This file now exposes those modules as first-class plugin runtimes so startup code can use a
+  generic plugin manager instead of hard-coded registration calls.
+- The current surface remains intentionally local and explicit: this is the bundled baseline,
+  while external package discovery is handled by the plugin manager.
 """
 
-from magnetar_prometheus.modules.email_module.steps import register_example_steps
-from magnetar_prometheus.modules.error_module.steps import register_error_steps
-from magnetar_prometheus.modules.linear_module.steps import register_linear_steps
-from magnetar_prometheus.modules.math_module.steps import register_math_steps
-from magnetar_prometheus.modules.http_module.steps import register_http_steps
+from magnetar_prometheus.modules.email_module.steps import (
+    ai_classify,
+    create_ticket,
+    extract_email_data,
+    fetch_emails,
+    manual_review,
+)
+from magnetar_prometheus.modules.error_module.steps import start_error, trigger_error
+from magnetar_prometheus.modules.http_module.steps import http_get, json_parse
+from magnetar_prometheus.modules.linear_module.steps import process_linear, start_linear
+from magnetar_prometheus.modules.math_module.steps import math_add, math_multiply
+from magnetar_prometheus.plugins.manager import PluginManager
+from magnetar_prometheus.plugins.models import PluginManifest, PluginRuntime
+
+
+def get_builtin_plugins() -> list[PluginRuntime]:
+    """Return the default bundled plugin set shipped with the repository."""
+    core_manifest = PluginManifest(
+        plugin_id="magnetar.core.examples",
+        version="1.0.0",
+        api_version="1",
+        description="Bundled deterministic example steps for local runs and tests.",
+        step_types={
+            "email.fetch": "python",
+            "email.extract": "python",
+            "ai.classify": "python",
+            "ticket.create": "python",
+            "review.queue": "python",
+            "linear.start": "python",
+            "linear.process": "python",
+            "error.start": "python",
+            "error.trigger": "python",
+            "math.add": "python",
+            "math.multiply": "python",
+            "http.get": "python",
+            "json.parse": "python",
+        },
+        compatibility={"python": ">=3.11"},
+    )
+
+    core_plugin = PluginRuntime(
+        manifest=core_manifest,
+        step_handlers={
+            "email.fetch": fetch_emails,
+            "email.extract": extract_email_data,
+            "ai.classify": ai_classify,
+            "ticket.create": create_ticket,
+            "review.queue": manual_review,
+            "linear.start": start_linear,
+            "linear.process": process_linear,
+            "error.start": start_error,
+            "error.trigger": trigger_error,
+            "math.add": math_add,
+            "math.multiply": math_multiply,
+            "http.get": http_get,
+            "json.parse": json_parse,
+        },
+    )
+
+    return [core_plugin]
 
 
 def register_all_example_steps(registry) -> None:
-    """Register every bundled example module into the provided step registry."""
-    register_example_steps(registry)
-    register_linear_steps(registry)
-    register_error_steps(registry)
-    register_math_steps(registry)
-    register_http_steps(registry)
+    """Backward-compatible helper that registers every bundled example step."""
+    plugin_manager = PluginManager()
+    plugin_manager.register_many(get_builtin_plugins())
+    plugin_manager.register_into(registry)

--- a/backend/src/magnetar_prometheus/plugins/__init__.py
+++ b/backend/src/magnetar_prometheus/plugins/__init__.py
@@ -1,0 +1,17 @@
+"""Plugin contracts and runtime helpers for MagnetarPrometheus.
+
+Why this package exists in this form:
+
+- The repository already had a module-level step registration path, but it lacked a reusable,
+  explicit plugin abstraction that can grow into package-based discovery and policy gating.
+- Keeping plugin contracts in their own package prevents the core engine from coupling itself
+  to a specific module layout while still allowing today's bundled examples to load unchanged.
+- The package starts intentionally small: contract objects, a manager, and discovery hooks.
+  This keeps the first slice easy to reason about and test while preserving room for future
+  policy, signatures, remote catalogs, and richer capability metadata.
+"""
+
+from magnetar_prometheus.plugins.manager import PluginManager
+from magnetar_prometheus.plugins.models import PluginManifest, PluginRuntime
+
+__all__ = ["PluginManifest", "PluginRuntime", "PluginManager"]

--- a/backend/src/magnetar_prometheus/plugins/bootstrap.py
+++ b/backend/src/magnetar_prometheus/plugins/bootstrap.py
@@ -1,0 +1,26 @@
+"""Plugin bootstrap helpers for runtime entrypoints.
+
+Why this file exists in this form:
+- CLI and API server entrypoints need a unified way to configure the plugin system.
+- Centralizing the startup wiring allows discovery and registration policies to evolve
+  in one place without duplicating boilerplate across the repository.
+"""
+
+from __future__ import annotations
+
+from magnetar_prometheus.modules.example_registry import get_builtin_plugins
+from magnetar_prometheus.plugins.manager import PluginManager
+from magnetar_prometheus.registry.step_registry import StepRegistry
+
+
+def build_plugin_manager(registry: StepRegistry) -> PluginManager:
+    """
+    Configure and register all builtin plugins into the given registry.
+
+    Centralizing this startup wiring allows API and CLI entrypoints to
+    share the same plugin initialization behavior.
+    """
+    plugin_manager = PluginManager()
+    plugin_manager.register_many(get_builtin_plugins())
+    plugin_manager.register_into(registry)
+    return plugin_manager

--- a/backend/src/magnetar_prometheus/plugins/manager.py
+++ b/backend/src/magnetar_prometheus/plugins/manager.py
@@ -12,11 +12,14 @@ Why this file exists in this form:
 
 from __future__ import annotations
 
+import logging
 from importlib.metadata import entry_points
 from typing import Dict, Iterable, List
 
 from magnetar_prometheus.plugins.models import PluginRuntime
 from magnetar_prometheus.registry.step_registry import StepRegistry
+
+logger = logging.getLogger(__name__)
 
 PLUGIN_API_VERSION = "1"
 PLUGIN_ENTRYPOINT_GROUP = "magnetar_prometheus.plugins"
@@ -83,8 +86,44 @@ class PluginManager:
         """
         discovered_plugins: List[PluginRuntime] = []
         for ep in entry_points(group=PLUGIN_ENTRYPOINT_GROUP):
-            provider = ep.load()
-            plugin = provider()
+            try:
+                provider = ep.load()
+            except Exception as exc:  # pragma: no cover - defensive error wrapping
+                logger.error(
+                    "Failed to load plugin entry point %r from group %r: %s",
+                    ep.name,
+                    PLUGIN_ENTRYPOINT_GROUP,
+                    exc,
+                )
+                continue
+
+            if not callable(provider):
+                logger.error(
+                    "Plugin entry point %r from group %r did not resolve to a callable provider, got %r",
+                    ep.name,
+                    PLUGIN_ENTRYPOINT_GROUP,
+                    type(provider),
+                )
+                continue
+
+            try:
+                plugin = provider()
+            except Exception as exc:  # pragma: no cover - defensive error wrapping
+                logger.error(
+                    "Plugin provider for entry point %r raised an exception during plugin instantiation: %s",
+                    ep.name,
+                    exc,
+                )
+                continue
+
+            if not isinstance(plugin, PluginRuntime):
+                logger.error(
+                    "Plugin provider for entry point %r returned %r, expected PluginRuntime",
+                    ep.name,
+                    type(plugin),
+                )
+                continue
+
             discovered_plugins.append(plugin)
         return discovered_plugins
 

--- a/backend/src/magnetar_prometheus/plugins/manager.py
+++ b/backend/src/magnetar_prometheus/plugins/manager.py
@@ -1,0 +1,103 @@
+"""Plugin discovery and registration orchestration for backend runtime startup.
+
+Why this file exists in this form:
+
+- The first plugin slice should be generic enough to host bundled modules today and
+  package-based plugins later, but small enough to keep failure modes obvious.
+- Startup discovery behavior is centralized here so CLI/API entrypoints can share one
+  deterministic path and avoid duplicate wiring logic.
+- The manager validates plugin contracts early, captures ownership diagnostics for step types,
+  and supports optional entry-point loading without making that path mandatory.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import entry_points
+from typing import Dict, Iterable, List
+
+from magnetar_prometheus.plugins.models import PluginRuntime
+from magnetar_prometheus.registry.step_registry import StepRegistry
+
+PLUGIN_API_VERSION = "1"
+PLUGIN_ENTRYPOINT_GROUP = "magnetar_prometheus.plugins"
+
+
+class PluginManager:
+    """Coordinate plugin discovery and registration for the step registry."""
+
+    def __init__(self, required_api_version: str = PLUGIN_API_VERSION):
+        self.required_api_version = required_api_version
+        self._plugins: Dict[str, PluginRuntime] = {}
+        self._step_owners: Dict[str, str] = {}
+
+    def register_plugin(self, plugin: PluginRuntime) -> None:
+        """Register a plugin after validating API compatibility and step ownership."""
+        manifest = plugin.manifest
+        if manifest.api_version != self.required_api_version:
+            raise ValueError(
+                f"Plugin '{manifest.plugin_id}' uses api_version '{manifest.api_version}' "
+                f"but runtime requires '{self.required_api_version}'."
+            )
+
+        if manifest.plugin_id in self._plugins:
+            raise ValueError(f"Plugin '{manifest.plugin_id}' is already registered.")
+
+        declared_step_types = set(manifest.step_types.keys())
+        implemented_step_types = set(plugin.step_handlers.keys())
+
+        missing_handlers = declared_step_types - implemented_step_types
+        if missing_handlers:
+            missing = ", ".join(sorted(missing_handlers))
+            raise ValueError(
+                f"Plugin '{manifest.plugin_id}' declares step types without handlers: {missing}."
+            )
+
+        undeclared_handlers = implemented_step_types - declared_step_types
+        if undeclared_handlers:
+            extra = ", ".join(sorted(undeclared_handlers))
+            raise ValueError(
+                f"Plugin '{manifest.plugin_id}' registers undeclared handlers: {extra}."
+            )
+
+        for step_type in declared_step_types:
+            if step_type in self._step_owners:
+                current_owner = self._step_owners[step_type]
+                raise ValueError(
+                    f"Step type '{step_type}' is already owned by plugin '{current_owner}'."
+                )
+
+        for step_type in declared_step_types:
+            self._step_owners[step_type] = manifest.plugin_id
+
+        self._plugins[manifest.plugin_id] = plugin
+
+    def register_many(self, plugins: Iterable[PluginRuntime]) -> None:
+        """Register a sequence of plugins in deterministic iteration order."""
+        for plugin in plugins:
+            self.register_plugin(plugin)
+
+    def discover_entrypoint_plugins(self) -> List[PluginRuntime]:
+        """Load plugins exposed via Python package entry points.
+
+        Each entry point must resolve to a zero-arg callable returning ``PluginRuntime``.
+        """
+        discovered_plugins: List[PluginRuntime] = []
+        for ep in entry_points(group=PLUGIN_ENTRYPOINT_GROUP):
+            provider = ep.load()
+            plugin = provider()
+            discovered_plugins.append(plugin)
+        return discovered_plugins
+
+    def register_into(self, registry: StepRegistry) -> None:
+        """Install every registered plugin step handler into the runtime registry."""
+        for plugin in self._plugins.values():
+            for step_type, handler in plugin.step_handlers.items():
+                registry.register(step_type, handler)
+
+    def list_plugins(self) -> List[str]:
+        """Return sorted plugin identifiers for diagnostics and CLI surfaces."""
+        return sorted(self._plugins.keys())
+
+    def describe_step_owners(self) -> Dict[str, str]:
+        """Return a copy of step-type ownership diagnostics."""
+        return dict(self._step_owners)

--- a/backend/src/magnetar_prometheus/plugins/models.py
+++ b/backend/src/magnetar_prometheus/plugins/models.py
@@ -1,0 +1,54 @@
+"""Typed plugin contracts for the MagnetarPrometheus backend runtime.
+
+Why this file exists in this form:
+
+- The codebase needs a formal plugin boundary so new capabilities can be added without editing
+  core orchestration code whenever a new module or executor type is introduced.
+- These models keep plugin metadata explicit and machine-validated, which makes startup
+  diagnostics and future compatibility checks far easier than ad-hoc dictionaries.
+- The contract is deliberately conservative in v1: it captures identity, compatibility, and
+  high-value capability metadata while leaving room for future extensibility.
+"""
+
+from dataclasses import dataclass, field
+from typing import Callable, Mapping
+
+from magnetar_prometheus_sdk.models import StepResult
+
+StepHandler = Callable[[dict, dict], StepResult]
+
+
+@dataclass(frozen=True)
+class PluginManifest:
+    """Describe one loadable plugin package for the runtime registry.
+
+    Attributes:
+        plugin_id: Stable unique identifier for the plugin.
+        version: Plugin package version.
+        api_version: Plugin API compatibility version expected by the runtime.
+        description: Human-readable short plugin summary.
+        step_types: Mapping of declared step type names to executor identifiers.
+        ui_metadata: Optional plugin-scoped UI metadata for future surfaces.
+        compatibility: Free-form compatibility metadata (e.g., python/backend constraints).
+    """
+
+    plugin_id: str
+    version: str
+    api_version: str
+    description: str
+    step_types: Mapping[str, str] = field(default_factory=dict)
+    ui_metadata: Mapping[str, object] = field(default_factory=dict)
+    compatibility: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PluginRuntime:
+    """Runtime-ready plugin bundle with manifest and step handlers.
+
+    Attributes:
+        manifest: Immutable plugin metadata used for diagnostics and policy checks.
+        step_handlers: Mapping of step type to Python callables used by the executor.
+    """
+
+    manifest: PluginManifest
+    step_handlers: Mapping[str, StepHandler] = field(default_factory=dict)

--- a/backend/tests/test_plugins.py
+++ b/backend/tests/test_plugins.py
@@ -103,3 +103,44 @@ def test_plugin_manager_rejects_manifest_handler_mismatch():
     )
     with pytest.raises(ValueError, match="undeclared handlers"):
         manager.register_plugin(extra_handler_plugin)
+
+
+def test_plugin_manager_rejects_duplicate_plugin_id_registration():
+    """Verify that a plugin ID can only be registered once."""
+    manager = PluginManager()
+    plugin = _make_test_plugin("plugin.duplicate", "step.one")
+    manager.register_plugin(plugin)
+
+    with pytest.raises(ValueError, match="already registered"):
+        manager.register_plugin(plugin)
+
+
+def test_plugin_manager_discovers_entrypoint_plugins(monkeypatch):
+    """Verify that plugins can be discovered via entry points."""
+    mock_plugin = _make_test_plugin("plugin.discovered", "step.discovered")
+
+    class MockEntryPoint:
+        def load(self):
+            return lambda: mock_plugin
+
+    def mock_entry_points(group=None):
+        if group == "magnetar_prometheus.plugins":
+            return [MockEntryPoint()]
+        return []
+
+    monkeypatch.setattr("magnetar_prometheus.plugins.manager.entry_points", mock_entry_points)
+
+    manager = PluginManager()
+    discovered = manager.discover_entrypoint_plugins()
+
+    assert len(discovered) == 1
+    assert discovered[0].manifest.plugin_id == "plugin.discovered"
+
+
+def test_plugin_manager_provides_step_ownership_diagnostics():
+    """Verify that the manager can report step-type ownership."""
+    manager = PluginManager()
+    manager.register_plugin(_make_test_plugin("plugin.owner", "step.owned"))
+
+    owners = manager.describe_step_owners()
+    assert owners == {"step.owned": "plugin.owner"}

--- a/backend/tests/test_plugins.py
+++ b/backend/tests/test_plugins.py
@@ -115,26 +115,49 @@ def test_plugin_manager_rejects_duplicate_plugin_id_registration():
         manager.register_plugin(plugin)
 
 
-def test_plugin_manager_discovers_entrypoint_plugins(monkeypatch):
-    """Verify that plugins can be discovered via entry points."""
+def test_plugin_manager_discovers_entrypoint_plugins(monkeypatch, caplog):
+    """Verify that plugins can be discovered via entry points with robust error handling."""
     mock_plugin = _make_test_plugin("plugin.discovered", "step.discovered")
 
     class MockEntryPoint:
+        def __init__(self, name, behavior="success"):
+            self.name = name
+            self.behavior = behavior
+
         def load(self):
+            if self.behavior == "load_fail":
+                raise RuntimeError("load failed")
+            if self.behavior == "not_callable":
+                return "not a callable"
+            if self.behavior == "call_fail":
+                return lambda: exec('raise RuntimeError("call failed")')
+            if self.behavior == "wrong_type":
+                return lambda: "not a plugin runtime"
             return lambda: mock_plugin
 
     def mock_entry_points(group=None):
         if group == "magnetar_prometheus.plugins":
-            return [MockEntryPoint()]
+            return [
+                MockEntryPoint("valid"),
+                MockEntryPoint("bad_load", "load_fail"),
+                MockEntryPoint("bad_provider", "not_callable"),
+                MockEntryPoint("bad_call", "call_fail"),
+                MockEntryPoint("bad_type", "wrong_type"),
+            ]
         return []
 
     monkeypatch.setattr("magnetar_prometheus.plugins.manager.entry_points", mock_entry_points)
 
     manager = PluginManager()
-    discovered = manager.discover_entrypoint_plugins()
+    with caplog.at_level("ERROR"):
+        discovered = manager.discover_entrypoint_plugins()
 
     assert len(discovered) == 1
     assert discovered[0].manifest.plugin_id == "plugin.discovered"
+    assert "Failed to load plugin entry point 'bad_load'" in caplog.text
+    assert "did not resolve to a callable provider" in caplog.text
+    assert "raised an exception during plugin instantiation" in caplog.text
+    assert "returned <class 'str'>, expected PluginRuntime" in caplog.text
 
 
 def test_plugin_manager_provides_step_ownership_diagnostics():

--- a/backend/tests/test_plugins.py
+++ b/backend/tests/test_plugins.py
@@ -1,0 +1,105 @@
+"""Contract tests for the backend plugin manager and bundled plugin metadata.
+
+Why this file exists in this form:
+
+- The repository now supports a generic plugin registration path for step handlers, so this
+  test module protects the contract that keeps plugin discovery deterministic and safe.
+- The tests verify both happy-path registration and failure-path validation (API mismatches,
+  duplicate step ownership, and inconsistent manifest/handler declarations).
+- A focused check against the bundled example plugin ensures the default CLI/API runtime keeps
+  exposing the expected step capabilities while being routed through the new plugin layer.
+"""
+
+import pytest
+
+from magnetar_prometheus.modules.example_registry import get_builtin_plugins
+from magnetar_prometheus.plugins.manager import PluginManager
+from magnetar_prometheus.plugins.models import PluginManifest, PluginRuntime
+from magnetar_prometheus.registry.step_registry import StepRegistry
+
+
+def _make_test_plugin(plugin_id: str, step_type: str) -> PluginRuntime:
+    """Create a tiny valid plugin used across multiple manager tests."""
+
+    def _handler(context, config):  # pragma: no cover - handler body not relevant to contract checks
+        return context, config
+
+    manifest = PluginManifest(
+        plugin_id=plugin_id,
+        version="1.0.0",
+        api_version="1",
+        description="test plugin",
+        step_types={step_type: "python"},
+    )
+    return PluginRuntime(manifest=manifest, step_handlers={step_type: _handler})
+
+
+def test_plugin_manager_registers_bundled_plugins_into_step_registry():
+    """Verify that bundled plugin handlers are installed into the runtime step registry."""
+    manager = PluginManager()
+    manager.register_many(get_builtin_plugins())
+
+    registry = StepRegistry()
+    manager.register_into(registry)
+
+    assert registry.get_handler("email.fetch") is not None
+    assert registry.get_handler("json.parse") is not None
+    assert "magnetar.core.examples" in manager.list_plugins()
+
+
+def test_plugin_manager_rejects_api_version_mismatch():
+    """Verify plugin registration fails when API versions are incompatible."""
+    manager = PluginManager(required_api_version="1")
+    plugin = PluginRuntime(
+        manifest=PluginManifest(
+            plugin_id="plugin.bad.version",
+            version="1.0.0",
+            api_version="2",
+            description="bad",
+            step_types={"x.step": "python"},
+        ),
+        step_handlers={"x.step": lambda _context, _config: None},
+    )
+
+    with pytest.raises(ValueError, match="runtime requires '1'"):
+        manager.register_plugin(plugin)
+
+
+def test_plugin_manager_rejects_duplicate_step_ownership():
+    """Verify two plugins cannot claim the same step type."""
+    manager = PluginManager()
+    manager.register_plugin(_make_test_plugin("plugin.one", "dup.step"))
+
+    with pytest.raises(ValueError, match="already owned"):
+        manager.register_plugin(_make_test_plugin("plugin.two", "dup.step"))
+
+
+def test_plugin_manager_rejects_manifest_handler_mismatch():
+    """Verify registration fails when declarations and handlers diverge."""
+    manager = PluginManager()
+
+    missing_handler_plugin = PluginRuntime(
+        manifest=PluginManifest(
+            plugin_id="plugin.missing.handler",
+            version="1.0.0",
+            api_version="1",
+            description="missing",
+            step_types={"declared.step": "python"},
+        ),
+        step_handlers={},
+    )
+    with pytest.raises(ValueError, match="without handlers"):
+        manager.register_plugin(missing_handler_plugin)
+
+    extra_handler_plugin = PluginRuntime(
+        manifest=PluginManifest(
+            plugin_id="plugin.extra.handler",
+            version="1.0.0",
+            api_version="1",
+            description="extra",
+            step_types={},
+        ),
+        step_handlers={"not.declared": lambda _context, _config: None},
+    )
+    with pytest.raises(ValueError, match="undeclared handlers"):
+        manager.register_plugin(extra_handler_plugin)

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.spec.ts
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.spec.ts
@@ -3,7 +3,7 @@
  *
  * This test validates the WorkflowStudioPageComponent.
  */
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { WorkflowStudioPageComponent } from './workflow-studio-page.component';
 
 describe('WorkflowStudioPageComponent', () => {
@@ -16,9 +16,7 @@ describe('WorkflowStudioPageComponent', () => {
     await TestBed.configureTestingModule({
       imports: [WorkflowStudioPageComponent]
     }).compileComponents();
-  });
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(WorkflowStudioPageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -28,10 +26,9 @@ describe('WorkflowStudioPageComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render the redesigned studio shell in English', () => {
+  it('should render the redesigned studio header and layout', () => {
     const element: HTMLElement = fixture.nativeElement;
-
-    expect(element.querySelector('h2')?.textContent).toContain('Workflow Studio');
+    expect(element.querySelector('.brand-block h2')?.textContent).toContain('Workflow Studio');
     expect(element.textContent).toContain('Visual editor workspace for building, testing, and debugging workflows.');
     expect(element.textContent).toContain('Run Workflow');
     expect(element.textContent).toContain('Save Local');
@@ -140,5 +137,175 @@ describe('WorkflowStudioPageComponent', () => {
     expect(studio.savedProjects[0].name).toBe('Blocked Save');
 
     setItemSpy.and.callThrough();
+  });
+
+  it('should select a node', () => {
+    const studio = component as any;
+    studio.selectNode('node_trigger');
+    expect(studio.selectedNodeId).toBe('node_trigger');
+    expect(studio.selectedNode?.id).toBe('node_trigger');
+  });
+
+  it('should update selected node label and summary', () => {
+    const studio = component as any;
+    studio.selectNode('node_trigger');
+    studio.updateSelectedNodeLabel('New Label');
+    studio.updateSelectedNodeSummary('New Summary');
+    expect(studio.selectedNode?.label).toBe('New Label');
+    expect(studio.selectedNode?.summary).toBe('New Summary');
+  });
+
+  it('should not update label or summary if no node is selected', () => {
+    const studio = component as any;
+    studio.selectedNodeId = 'non-existent';
+    
+    // Trigger branch where selectedNode is null
+    expect(studio.selectedNode).toBeNull();
+    expect(studio.selectedNodeType).toBeNull();
+    
+    studio.updateSelectedNodeLabel('New Label');
+    studio.updateSelectedNodeSummary('New Summary');
+    // Still null
+    expect(studio.selectedNode).toBeNull();
+  });
+
+  it('should use default name if project name is empty on save', () => {
+    const studio = component as any;
+    studio.projectName = '   ';
+    studio.saveProject();
+    expect(studio.savedProjects[0].name).toBe('Untitled Workflow');
+  });
+
+  it('should do nothing if loadProject is called without id', () => {
+    const studio = component as any;
+    const initialStatus = studio.statusMessage;
+    studio.loadProject(null);
+    expect(studio.statusMessage).toBe(initialStatus);
+  });
+
+  it('should set error message if project to load does not exist', () => {
+    const studio = component as any;
+    studio.loadProject('non-existent');
+    expect(studio.statusMessage).toContain('Unable to load project');
+  });
+
+  it('should fallback to first node if loaded project has invalid selectedNodeId', () => {
+    const studio = component as any;
+    studio.savedProjects = [{
+      id: 'p1',
+      name: 'P1',
+      selectedNodeId: 'invalid',
+      nodes: [{ id: 'n1', typeId: 't1', label: 'L', summary: 'S', x: 0, y: 0 }]
+    }];
+    studio.loadProject('p1');
+    expect(studio.selectedNodeId).toBe('n1');
+  });
+
+  it('should fallback to empty string if loaded project has no nodes', () => {
+    const studio = component as any;
+    studio.savedProjects = [{
+      id: 'p_empty',
+      name: 'Empty',
+      selectedNodeId: 'n1',
+      nodes: []
+    }];
+    studio.loadProject('p_empty');
+    expect(studio.selectedNodeId).toBe('');
+  });
+
+  it('should handle newProject with empty default nodes safely', () => {
+    const studio = component as any;
+    studio.defaultNodes = [];
+    studio.newProject();
+    expect(studio.selectedNodeId).toBe('');
+  });
+
+  it('should return default node type if typeId is unknown', () => {
+    const studio = component as any;
+    const type = studio.getNodeType('unknown');
+    expect(type.id).toBe(studio.nodeTypes[0].id);
+  });
+
+  it('should run workflow and complete steps', fakeAsync(() => {
+    const studio = component as any;
+    studio.newProject();
+    fixture.detectChanges();
+    studio.runWorkflow();
+    expect(studio.isRunning).toBeTrue();
+    tick(10000); 
+    fixture.detectChanges();
+    expect(studio.isRunning).toBeFalse();
+    expect(studio.activeNodeId).toBeNull();
+    expect(studio.completedNodeIds.size).toBeGreaterThan(0);
+  }));
+
+  it('should not run workflow if already running', () => {
+    const studio = component as any;
+    studio.runWorkflow();
+    const initialTimers = studio.timers.length;
+    studio.runWorkflow();
+    expect(studio.timers.length).toBe(initialTimers);
+  });
+
+  it('should handle local storage being unavailable during restore', () => {
+    const studio = component as any;
+    spyOn(studio, 'getLocalStorage').and.returnValue(null);
+    studio.restoreProjects();
+    expect(studio.statusMessage).toContain('Local storage is unavailable');
+  });
+
+  it('should handle JSON parse error during restore', () => {
+    localStorage.setItem('mp.workflowStudio.projects.v1', 'invalid-json');
+    const studio = component as any;
+    studio.restoreProjects();
+    expect(studio.statusMessage).toContain('Could not parse saved projects');
+  });
+
+  it('should handle non-array data in local storage during restore', () => {
+    localStorage.setItem('mp.workflowStudio.projects.v1', JSON.stringify({ not: 'an-array' }));
+    const studio = component as any;
+    studio.restoreProjects();
+    expect(studio.savedProjects).toEqual([]);
+  });
+
+  it('should return false if persist fails due to missing storage', () => {
+    const studio = component as any;
+    spyOn(studio, 'getLocalStorage').and.returnValue(null);
+    const result = studio.persistProjects();
+    expect(result).toBeFalse();
+  });
+
+  it('should use fallback project id if randomUUID is unavailable', () => {
+    const studio = component as any;
+    spyOnProperty(globalThis, 'crypto', 'get').and.returnValue({} as any);
+    const id = studio.createProjectId();
+    expect(id).toContain('project_');
+  });
+
+  it('should clear timers on destroy', () => {
+    const studio = component as any;
+    studio.runWorkflow();
+    expect(studio.timers.length).toBeGreaterThan(0);
+    const clearSpy = spyOn(globalThis, 'clearTimeout').and.callThrough();
+    component.ngOnDestroy();
+    expect(clearSpy).toHaveBeenCalled();
+    expect(studio.timers.length).toBe(0);
+  });
+
+  it('should return null from getLocalStorage if globalThis.localStorage is undefined', () => {
+    const studio = component as any;
+    const originalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, 'localStorage', {
+      get: () => undefined,
+      configurable: true
+    });
+    
+    expect(studio.getLocalStorage()).toBeNull();
+    
+    // Restore
+    Object.defineProperty(globalThis, 'localStorage', {
+      get: () => originalStorage,
+      configurable: true
+    });
   });
 });


### PR DESCRIPTION
### Motivation

- Provide a formal plugin boundary so step capabilities can be added without editing core engine wiring. 
- Replace hard-coded example step registration with a reusable plugin assembly to make startup diagnostics and ownership checks deterministic.
- Surface typed plugin metadata and early compatibility/ownership validation to prevent runtime conflicts and simplify future discovery/policy work.

### Description

- Add a `plugins` package with `models.py` (typed `PluginManifest`/`PluginRuntime`) and `manager.py` (`PluginManager`) implementing API-version checks, step-ownership conflict detection, entry-point discovery, and registration into the `StepRegistry`.
- Convert bundled example modules into a first-class plugin bundle via `modules/example_registry.py` exposing `get_builtin_plugins()` and making `register_all_example_steps()` a backward-compatible helper that avoids redundant manager overhead.
- **[NEW]** Centralize startup wiring in `backend/src/magnetar_prometheus/plugins/bootstrap.py` to remove duplication across CLI and API server entrypoints.
- **[NEW]** Harden `PluginManager.discover_entrypoint_plugins` with robust `try/except` blocks, type validation, and logging to handle faulty third-party plugins gracefully.
- Update documentation files (`README.md`, `ARCHITECTURE.md`, `PLAN.md`, `STATUS.md`) to describe the new plugin-ready runtime and shipped capabilities, and standardize on the hyphenated "step-capability" terminology.
- Expand contract tests (`backend/tests/test_plugins.py`) to validate registration, API-version validation, duplicate ownership rejection, and manifest/handler consistency.

### Testing & Quality

- **100.00% Backend Coverage**: Verified via `bash scripts/run_tests.sh backend`. All 118 tests pass, including new error-handling and discovery paths.
- **100.00% UI Coverage**: Verified via `bash scripts/run_tests.sh ui`. Expanded `workflow-studio-page.component.spec.ts` to cover all statements, branches, functions, and lines (102 tests) in the Workflow Studio feature.
- **UI Contract Guard**: Verified that `WorkflowStudioPageComponent` now uses explicit `public` modifiers for lifecycle hooks as required by project conventions.

### Related Discussions
- Related to Discussion #60