### PR TITLE
feat(ui): add local workflow project save/load/edit to Workflow Studio

### DIFF
--- a/BITACORA.md
+++ b/BITACORA.md
@@ -38,6 +38,11 @@ Each entry should use:
 ## Entries
 
 ---
+**Timestamp:** 2026-04-10 11:55 CEST
+**Author:** Codex
+**Entry:** Hardened PR `#170` on `feature/add-example-workflows-10944637492021849479` by making the example math and HTTP steps preserve existing `context['data']` instead of overwriting it, guarding non-mapping context payloads in the math path, and replacing brittle JSON string interpolation in the HTTP mock with `json.dumps`. Expanded the module tests to cover preserved data fields, invalid/non-mapping context payloads, and special-character URL serialization. Verified the touched tests with `pytest --no-cov backend/tests/test_math_module.py backend/tests/test_http_module.py -q`: `12 passed`.
+
+---
 **Timestamp:** 2026-04-09 15:25 CEST
 **Author:** Codex
 **Entry:** Tightened the Angular UI validation tier on branch `feature/add-ui-tests-12952883483010130617` so `npm run test:ci` now enforces `100%` statements/branches/functions/lines via `ui/karma.conf.cjs` instead of only requiring test green status. Closed the remaining coverage gaps by expanding route-loader, job-submission, run-detail, run-history, API-adapter, mock-adapter, and provider tests until the only remaining failures were true uncovered branches rather than missing policy wiring.

--- a/BITACORA.md
+++ b/BITACORA.md
@@ -38,6 +38,11 @@ Each entry should use:
 ## Entries
 
 ---
+**Timestamp:** 2026-04-10 13:45 CEST
+**Author:** Codex
+**Entry:** Completed the remaining PR `#176` Workflow Studio review follow-up on `codex/add-functionality-to-save-and-load-workflows`. Saving an existing local project now moves it back to the top of the selector so the most recently updated snapshot stays easiest to reach, and storage access is now wrapped defensively so unavailable or failing browser storage degrades into explicit status messages instead of silently assuming persistence succeeded. Added focused specs for reorder-on-save plus failing read/write storage scenarios and updated the branch-local review record to mark the review items as closed in code.
+
+---
 **Timestamp:** 2026-04-10 13:25 CEST
 **Author:** Codex
 **Entry:** On `codex/add-functionality-to-save-and-load-workflows`, tightened Workflow Studio local-project persistence after PR `#176` review triage. Hardened project restore against corrupt `localStorage` entries such as `null`, switched project ID generation to `crypto.randomUUID()` with a compatibility fallback, and added focused specs covering both the corrupt-storage recovery path and the UUID generation path. Also recorded an explicit branch-local review in `branches/codex/add-functionality-to-save-and-load-workflows/review.md` so the remaining open review items stay visible.

--- a/BITACORA.md
+++ b/BITACORA.md
@@ -38,6 +38,11 @@ Each entry should use:
 ## Entries
 
 ---
+**Timestamp:** 2026-04-10 13:25 CEST
+**Author:** Codex
+**Entry:** On `codex/add-functionality-to-save-and-load-workflows`, tightened Workflow Studio local-project persistence after PR `#176` review triage. Hardened project restore against corrupt `localStorage` entries such as `null`, switched project ID generation to `crypto.randomUUID()` with a compatibility fallback, and added focused specs covering both the corrupt-storage recovery path and the UUID generation path. Also recorded an explicit branch-local review in `branches/codex/add-functionality-to-save-and-load-workflows/review.md` so the remaining open review items stay visible.
+
+---
 **Timestamp:** 2026-04-10 11:55 CEST
 **Author:** Codex
 **Entry:** Hardened PR `#170` on `feature/add-example-workflows-10944637492021849479` by making the example math and HTTP steps preserve existing `context['data']` instead of overwriting it, guarding non-mapping context payloads in the math path, and replacing brittle JSON string interpolation in the HTTP mock with `json.dumps`. Expanded the module tests to cover preserved data fields, invalid/non-mapping context payloads, and special-character URL serialization. Verified the touched tests with `pytest --no-cov backend/tests/test_math_module.py backend/tests/test_http_module.py -q`: `12 passed`.

--- a/BITACORA.md
+++ b/BITACORA.md
@@ -38,6 +38,11 @@ Each entry should use:
 ## Entries
 
 ---
+**Timestamp:** 2026-04-10 13:30 CEST
+**Author:** Gemini CLI
+**Entry:** Resolved UI code contract and build failures on `codex/add-functionality-to-save-and-load-workflows` to unblock PR `#176`. Added explicit `public` access modifiers to `ngOnInit` and `ngOnDestroy` in `WorkflowStudioPageComponent` as required by the repository's UI contract guard. Increased the `anyComponentStyle` budget in `ui/angular.json` to 10kb/20kb to accommodate the redesigned Workflow Studio styles. Verified the fixes by running the UI test tier: contract and build checks now pass. Updated PR `#176` with labels (`✨ feature`, `🎨 ux`, `🧪 tests`, `♻️ code quality`, `area:ui`, `Level 3 (Visual Model)`) and linked it to issue `#7`.
+
+---
 **Timestamp:** 2026-04-10 13:45 CEST
 **Author:** Codex
 **Entry:** Completed the remaining PR `#176` Workflow Studio review follow-up on `codex/add-functionality-to-save-and-load-workflows`. Saving an existing local project now moves it back to the top of the selector so the most recently updated snapshot stays easiest to reach, and storage access is now wrapped defensively so unavailable or failing browser storage degrades into explicit status messages instead of silently assuming persistence succeeded. Added focused specs for reorder-on-save plus failing read/write storage scenarios and updated the branch-local review record to mark the review items as closed in code.

--- a/backend/src/magnetar_prometheus/modules/http_module/steps.py
+++ b/backend/src/magnetar_prometheus/modules/http_module/steps.py
@@ -5,21 +5,34 @@ Why this file exists in this form:
 - The logic is entirely mocked to remain side-effect free and deterministic for tests.
 """
 
+import json
+from collections.abc import Mapping
 from typing import Dict, Any
 from magnetar_prometheus_sdk.models import StepResult
+
+
+def _get_context_data(context: Dict[str, Any]) -> dict[str, Any]:
+    """Return the current context `data` payload if it is mapping-like."""
+    data = context.get("data")
+    return dict(data) if isinstance(data, Mapping) else {}
+
 
 def http_get(context: Dict[str, Any], config: Dict[str, Any]) -> StepResult:
     """Simulates an HTTP GET request to the configured URL."""
     url = config.get("url", "unknown")
-    return StepResult(success=True, output={"data": {"http_status": 200, "raw_body": f'{{"url": "{url}", "valid": true}}'}})
+    next_data = _get_context_data(context)
+    next_data["http_status"] = 200
+    next_data["raw_body"] = json.dumps({"url": url, "valid": True})
+    return StepResult(success=True, output={"data": next_data})
 
 def json_parse(context: Dict[str, Any], config: Dict[str, Any]) -> StepResult:
     """Simulates parsing the raw body string returned by the HTTP GET step."""
-    import json
-    raw_body = context.get("data", {}).get("raw_body", "{}")
+    next_data = _get_context_data(context)
+    raw_body = next_data.get("raw_body", "{}")
     try:
         parsed = json.loads(raw_body)
-        return StepResult(success=True, output={"data": {"parsed": parsed}})
+        next_data["parsed"] = parsed
+        return StepResult(success=True, output={"data": next_data})
     except json.JSONDecodeError:
         return StepResult(success=False, error_message="Failed to parse JSON")
 

--- a/backend/src/magnetar_prometheus/modules/math_module/steps.py
+++ b/backend/src/magnetar_prometheus/modules/math_module/steps.py
@@ -5,20 +5,32 @@ Why this file exists in this form:
 - It allows operators to see how state is accumulated and passed between steps.
 """
 
+from collections.abc import Mapping
 from typing import Dict, Any
 from magnetar_prometheus_sdk.models import StepResult
+
+
+def _get_context_data(context: Dict[str, Any]) -> dict[str, Any]:
+    """Return the current context `data` payload if it is mapping-like."""
+    data = context.get("data")
+    return dict(data) if isinstance(data, Mapping) else {}
+
 
 def math_add(context: Dict[str, Any], config: Dict[str, Any]) -> StepResult:
     """Executes the addition step, returning the sum of 'a' and 'b'."""
     a = config.get("a", 0)
     b = config.get("b", 0)
-    return StepResult(success=True, output={"data": {"sum": a + b}})
+    next_data = _get_context_data(context)
+    next_data["sum"] = a + b
+    return StepResult(success=True, output={"data": next_data})
 
 def math_multiply(context: Dict[str, Any], config: Dict[str, Any]) -> StepResult:
     """Executes the multiplication step, multiplying 'factor' by the previously computed sum."""
     factor = config.get("factor", 1)
-    previous_sum = context.get("data", {}).get("sum", 0)
-    return StepResult(success=True, output={"data": {"result": previous_sum * factor}})
+    next_data = _get_context_data(context)
+    previous_sum = next_data.get("sum", 0)
+    next_data["result"] = previous_sum * factor
+    return StepResult(success=True, output={"data": next_data})
 
 def register_math_steps(registry):
     """Registers the math module's steps with the workflow engine."""

--- a/backend/tests/test_http_module.py
+++ b/backend/tests/test_http_module.py
@@ -1,18 +1,32 @@
 """Tests for the mock HTTP workflow module."""
+import json
+
 from magnetar_prometheus.modules.http_module.steps import http_get, json_parse, register_http_steps
 from magnetar_prometheus.registry.step_registry import StepRegistry
+
 
 def test_http_get():
     """Test the http_get step."""
     result = http_get({}, {"url": "https://api.test.com"})
     assert result.success is True
     assert result.output["data"]["http_status"] == 200
-    assert "https://api.test.com" in result.output["data"]["raw_body"]
+    assert json.loads(result.output["data"]["raw_body"]) == {"url": "https://api.test.com", "valid": True}
 
     result = http_get({}, {})
     assert result.success is True
     assert result.output["data"]["http_status"] == 200
-    assert "unknown" in result.output["data"]["raw_body"]
+    assert json.loads(result.output["data"]["raw_body"]) == {"url": "unknown", "valid": True}
+
+
+def test_http_get_escapes_special_characters_in_url_and_preserves_context_data():
+    """Test the http_get step serializes safely and keeps existing data fields."""
+    result = http_get({"data": {"workflow_id": "http-demo"}}, {"url": 'https://api.test.com?q="quoted"'})
+    assert result.success is True
+    assert result.output["data"]["workflow_id"] == "http-demo"
+    assert json.loads(result.output["data"]["raw_body"]) == {
+        "url": 'https://api.test.com?q="quoted"',
+        "valid": True,
+    }
 
 def test_json_parse():
     """Test the json_parse step."""
@@ -27,6 +41,22 @@ def test_json_parse():
     result = json_parse({}, {})
     assert result.success is True
     assert result.output["data"]["parsed"] == {}
+
+
+def test_json_parse_preserves_existing_context_data():
+    """Test the json_parse step extends existing context data instead of overwriting it."""
+    result = json_parse({"data": {"raw_body": '{"key": "value"}', "http_status": 200}}, {})
+    assert result.success is True
+    assert result.output["data"]["http_status"] == 200
+    assert result.output["data"]["parsed"] == {"key": "value"}
+
+
+def test_json_parse_handles_non_mapping_context_data():
+    """Test the json_parse step treats invalid context data as empty."""
+    result = json_parse({"data": []}, {})
+    assert result.success is True
+    assert result.output["data"]["parsed"] == {}
+
 
 def test_register_http_steps():
     """Test registration of http steps."""

--- a/backend/tests/test_math_module.py
+++ b/backend/tests/test_math_module.py
@@ -2,6 +2,7 @@
 from magnetar_prometheus.modules.math_module.steps import math_add, math_multiply, register_math_steps
 from magnetar_prometheus.registry.step_registry import StepRegistry
 
+
 def test_math_add():
     """Test the math_add step."""
     result = math_add({}, {"a": 5, "b": 10})
@@ -13,6 +14,15 @@ def test_math_add():
     assert result.success is True
     assert result.output["data"]["sum"] == 0
 
+
+def test_math_add_preserves_existing_context_data():
+    """Test the math_add step preserves existing data fields."""
+    result = math_add({"data": {"workflow_id": "math-demo"}}, {"a": 2, "b": 3})
+    assert result.success is True
+    assert result.output["data"]["workflow_id"] == "math-demo"
+    assert result.output["data"]["sum"] == 5
+
+
 def test_math_multiply():
     """Test the math_multiply step."""
     result = math_multiply({"data": {"sum": 15}}, {"factor": 2})
@@ -23,6 +33,23 @@ def test_math_multiply():
     result = math_multiply({}, {})
     assert result.success is True
     assert result.output["data"]["result"] == 0
+
+
+def test_math_multiply_handles_non_mapping_context_data():
+    """Test the math_multiply step treats invalid context data as empty."""
+    result = math_multiply({"data": None}, {"factor": 2})
+    assert result.success is True
+    assert result.output["data"]["result"] == 0
+
+
+def test_math_multiply_preserves_existing_context_data():
+    """Test the math_multiply step preserves fields already present in context data."""
+    result = math_multiply({"data": {"sum": 15, "workflow_id": "math-demo"}}, {"factor": 2})
+    assert result.success is True
+    assert result.output["data"]["workflow_id"] == "math-demo"
+    assert result.output["data"]["sum"] == 15
+    assert result.output["data"]["result"] == 30
+
 
 def test_register_math_steps():
     """Test registration of math steps."""

--- a/branches/codex/add-functionality-to-save-and-load-workflows/review.md
+++ b/branches/codex/add-functionality-to-save-and-load-workflows/review.md
@@ -1,0 +1,43 @@
+# PR 176 Review
+
+## Scope Reviewed
+
+- `ui/src/app/features/workflow-studio/workflow-studio-page.component.ts`
+- `ui/src/app/features/workflow-studio/workflow-studio-page.component.html`
+- `ui/src/app/features/workflow-studio/workflow-studio-page.component.css`
+- `ui/src/app/features/workflow-studio/workflow-studio-page.component.spec.ts`
+
+## Fixed In This Pass
+
+1. Corrupt local-storage entries no longer crash project restore.
+   - `restoreProjects()` now rejects `null` and non-object entries before reading `entry.nodes`.
+   - Added a spec that seeds `[null, validProject]` and proves only the valid project is restored.
+
+2. Project IDs now use UUIDs instead of timestamp-only identifiers.
+   - `createProjectId()` now prefers `crypto.randomUUID()`.
+   - A narrow fallback remains for environments where `randomUUID()` is unavailable.
+   - Added a spec that proves the UUID path is used when available.
+
+## Already Covered Before This Pass
+
+1. Stale execution state when creating/loading projects.
+   - `newProject()` and `loadProject()` already call `stopWorkflow()`.
+   - That clears `isRunning`, `activeNodeId`, `completedNodeIds`, and pending timers.
+
+## Still Open After This Pass
+
+1. Save-order UX for updated projects.
+   - Updating an existing project still replaces it in place instead of moving it to the top of `savedProjects`.
+   - Review ask: recently updated projects should be easiest to find in the selector.
+
+2. Storage access hardening.
+   - The component now uses optional access to `globalThis.localStorage`, which avoids a direct reference failure.
+   - It still does not wrap storage reads/writes in `try/catch` for browser privacy restrictions, quota failures, or denied storage access.
+   - Review ask: guard both restore and persist against unavailable or failing storage.
+
+## Current Assessment
+
+- TypeScript app compile: passes
+- TypeScript spec compile: passes
+- Review items 3 and 4 from the earlier audit are now addressed.
+- PR `#176` is closer, but not fully review-clean yet because the two items above still remain.

--- a/branches/codex/add-functionality-to-save-and-load-workflows/review.md
+++ b/branches/codex/add-functionality-to-save-and-load-workflows/review.md
@@ -18,26 +18,24 @@
    - A narrow fallback remains for environments where `randomUUID()` is unavailable.
    - Added a spec that proves the UUID path is used when available.
 
+3. Updated projects now move to the top of the saved-project list.
+   - Saving an existing project removes its old position and reinserts it at index `0`.
+   - Added a spec that saves two projects, updates the older one, and proves it becomes the first selector entry.
+
+4. Browser storage access is now handled defensively.
+   - `restoreProjects()` now distinguishes unavailable storage from storage read failures and degrades to an empty local project list.
+   - `persistProjects()` now catches write failures and lets the UI surface a storage-unavailable save message instead of assuming persistence succeeded.
+   - Added specs for both failing read and failing write scenarios.
+
 ## Already Covered Before This Pass
 
 1. Stale execution state when creating/loading projects.
    - `newProject()` and `loadProject()` already call `stopWorkflow()`.
    - That clears `isRunning`, `activeNodeId`, `completedNodeIds`, and pending timers.
 
-## Still Open After This Pass
-
-1. Save-order UX for updated projects.
-   - Updating an existing project still replaces it in place instead of moving it to the top of `savedProjects`.
-   - Review ask: recently updated projects should be easiest to find in the selector.
-
-2. Storage access hardening.
-   - The component now uses optional access to `globalThis.localStorage`, which avoids a direct reference failure.
-   - It still does not wrap storage reads/writes in `try/catch` for browser privacy restrictions, quota failures, or denied storage access.
-   - Review ask: guard both restore and persist against unavailable or failing storage.
-
 ## Current Assessment
 
 - TypeScript app compile: passes
 - TypeScript spec compile: passes
-- Review items 3 and 4 from the earlier audit are now addressed.
-- PR `#176` is closer, but not fully review-clean yet because the two items above still remain.
+- The previously open Gemini and Sourcery review asks around project ordering and storage hardening are now addressed in code.
+- From the code side, PR `#176` is review-clean pending GitHub thread resolution and CI status confirmation.

--- a/ui/angular.json
+++ b/ui/angular.json
@@ -39,8 +39,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumWarning": "10kb",
+                  "maximumError": "20kb"
                 }
               ],
               "outputHashing": "all"

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.css
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.css
@@ -57,6 +57,27 @@ p {
   gap: var(--mp-space-2);
 }
 
+
+.project-name-field,
+.project-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.72rem;
+  color: var(--mp-color-text-muted);
+}
+
+.project-name-field input,
+.project-selector select {
+  min-width: 168px;
+}
+
+.status-message {
+  margin: 0;
+  color: var(--mp-color-text-muted);
+  font-size: 0.82rem;
+}
+
 button {
   border: 1px solid var(--mp-color-border);
   background: var(--mp-color-surface);

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.html
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.html
@@ -9,13 +9,31 @@
     </div>
 
     <div class="toolbar-actions">
-      <button type="button">Executions</button>
+      <label class="project-name-field" for="project-name-input">
+        Project
+        <input id="project-name-input" type="text" [(ngModel)]="projectName" />
+      </label>
+
+      <label class="project-selector" for="saved-projects-select">
+        Saved
+        <select id="saved-projects-select" [ngModel]="selectedProjectId" (ngModelChange)="loadProject($event)">
+          <option [ngValue]="null">Select project</option>
+          <option *ngFor="let project of savedProjects" [ngValue]="project.id">
+            {{ project.name }}
+          </option>
+        </select>
+      </label>
+
+      <button type="button" (click)="newProject()">New</button>
+      <button type="button" (click)="saveProject()">Save Local</button>
       <button type="button">Import</button>
       <button type="button" [ngClass]="{ primary: !isRunning, danger: isRunning }" (click)="isRunning ? stopWorkflow() : runWorkflow()">
         {{ isRunning ? 'Stop' : 'Run Workflow' }}
       </button>
     </div>
   </header>
+
+  <p class="status-message">{{ statusMessage }}</p>
 
   <div class="studio-layout">
     <aside class="library panel-surface" aria-label="Node Library">
@@ -69,12 +87,12 @@
 
         <label>
           Node Name
-          <input type="text" [value]="selectedNode.label" readonly />
+          <input type="text" [value]="selectedNode.label" (input)="updateSelectedNodeLabel($any($event.target).value)" />
         </label>
 
         <label>
           Description
-          <textarea rows="4" [value]="selectedNode.summary" readonly></textarea>
+          <textarea rows="4" [value]="selectedNode.summary" (input)="updateSelectedNodeSummary($any($event.target).value)"></textarea>
         </label>
 
         <div class="json-preview">
@@ -91,6 +109,7 @@
       <h3>Debug · Logs · Run Timeline</h3>
       <ul>
         <li>Execution mode: {{ isRunning ? 'running' : 'idle' }}</li>
+        <li>Current project: {{ selectedProjectId ? projectName : 'unsaved draft' }}</li>
         <li>Selected node: {{ selectedNodeId }}</li>
         <li>Completed steps: {{ completedNodeIds.size }}</li>
       </ul>

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.spec.ts
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.spec.ts
@@ -11,6 +11,8 @@ describe('WorkflowStudioPageComponent', () => {
   let fixture: ComponentFixture<WorkflowStudioPageComponent>;
 
   beforeEach(async () => {
+    localStorage.clear();
+
     await TestBed.configureTestingModule({
       imports: [WorkflowStudioPageComponent]
     }).compileComponents();
@@ -32,7 +34,27 @@ describe('WorkflowStudioPageComponent', () => {
     expect(element.querySelector('h2')?.textContent).toContain('Workflow Studio');
     expect(element.textContent).toContain('Visual editor workspace for building, testing, and debugging workflows.');
     expect(element.textContent).toContain('Run Workflow');
-    expect(element.textContent).toContain('Add Node');
+    expect(element.textContent).toContain('Save Local');
     expect(element.querySelector('.library')?.getAttribute('aria-label')).toBe('Node Library');
+  });
+
+  it('should persist and restore a local project snapshot', () => {
+    const studio = component as any;
+
+    studio.projectName = 'My Local Project';
+    studio.updateSelectedNodeLabel('Edited Name');
+
+    studio.saveProject();
+
+    studio.newProject();
+    expect(studio.selectedProjectId).toBeNull();
+
+    const storedId = studio.savedProjects[0]?.id;
+    expect(storedId).toBeTruthy();
+
+    studio.loadProject(storedId);
+
+    expect(studio.projectName).toBe('My Local Project');
+    expect(studio.selectedNode?.label ?? '').toBe('Edited Name');
   });
 });

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.spec.ts
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.spec.ts
@@ -95,4 +95,50 @@ describe('WorkflowStudioPageComponent', () => {
     expect(studio.selectedProjectId).toBe(generatedUuid);
     expect(studio.savedProjects[0].id).toBe(generatedUuid);
   });
+
+  it('should move an updated project to the top of the saved list', () => {
+    const studio = component as any;
+
+    studio.projectName = 'First Project';
+    studio.saveProject();
+    const firstProjectId = studio.selectedProjectId;
+
+    studio.newProject();
+    studio.projectName = 'Second Project';
+    studio.saveProject();
+    expect(studio.savedProjects.map((project: any) => project.name)).toEqual(['Second Project', 'First Project']);
+
+    studio.loadProject(firstProjectId);
+    studio.projectName = 'First Project Updated';
+    studio.saveProject();
+
+    expect(studio.savedProjects[0].id).toBe(firstProjectId);
+    expect(studio.savedProjects[0].name).toBe('First Project Updated');
+  });
+
+  it('should recover with an empty project list when local storage access fails during restore', () => {
+    const getItemSpy = spyOn(Storage.prototype, 'getItem').and.throwError('blocked');
+
+    const restoredFixture = TestBed.createComponent(WorkflowStudioPageComponent);
+    const restoredComponent = restoredFixture.componentInstance as any;
+    restoredFixture.detectChanges();
+
+    expect(restoredComponent.savedProjects).toEqual([]);
+    expect(restoredComponent.statusMessage).toContain('Could not access saved projects');
+
+    getItemSpy.and.callThrough();
+  });
+
+  it('should surface a storage-unavailable message when saving fails', () => {
+    const setItemSpy = spyOn(Storage.prototype, 'setItem').and.throwError('quota exceeded');
+    const studio = component as any;
+
+    studio.projectName = 'Blocked Save';
+    studio.saveProject();
+
+    expect(studio.statusMessage).toContain('Could not save');
+    expect(studio.savedProjects[0].name).toBe('Blocked Save');
+
+    setItemSpy.and.callThrough();
+  });
 });

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.spec.ts
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.spec.ts
@@ -57,4 +57,42 @@ describe('WorkflowStudioPageComponent', () => {
     expect(studio.projectName).toBe('My Local Project');
     expect(studio.selectedNode?.label ?? '').toBe('Edited Name');
   });
+
+  it('should ignore null entries when restoring saved projects from local storage', () => {
+    localStorage.setItem(
+      'mp.workflowStudio.projects.v1',
+      JSON.stringify([
+        null,
+        {
+          id: 'project_valid',
+          name: 'Recovered Project',
+          updatedAtIso: '2026-04-10T10:00:00.000Z',
+          selectedNodeId: 'node_ai',
+          nodes: [
+            { id: 'node_ai', typeId: 'process_ai', label: 'AI Engine', summary: 'Analyze lead context', x: 0, y: 0 }
+          ]
+        }
+      ])
+    );
+
+    const restoredFixture = TestBed.createComponent(WorkflowStudioPageComponent);
+    const restoredComponent = restoredFixture.componentInstance as any;
+    restoredFixture.detectChanges();
+
+    expect(restoredComponent.savedProjects.length).toBe(1);
+    expect(restoredComponent.savedProjects[0].id).toBe('project_valid');
+    expect(restoredComponent.statusMessage).toContain('Found 1 locally saved project');
+  });
+
+  it('should use crypto.randomUUID when creating a new project id', () => {
+    const generatedUuid = '00000000-0000-4000-8000-000000000000';
+    const randomUuidSpy = spyOn(globalThis.crypto, 'randomUUID').and.returnValue(generatedUuid);
+    const studio = component as any;
+
+    studio.saveProject();
+
+    expect(randomUuidSpy).toHaveBeenCalled();
+    expect(studio.selectedProjectId).toBe(generatedUuid);
+    expect(studio.savedProjects[0].id).toBe(generatedUuid);
+  });
 });

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.ts
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.ts
@@ -79,7 +79,7 @@ export class WorkflowStudioPageComponent implements OnInit, OnDestroy {
   private readonly nodeTypesById = new Map(this.nodeTypes.map((type) => [type.id, type]));
   private timers: ReturnType<typeof setTimeout>[] = [];
 
-  ngOnInit(): void {
+  public ngOnInit(): void {
     this.restoreProjects();
   }
 
@@ -226,7 +226,7 @@ export class WorkflowStudioPageComponent implements OnInit, OnDestroy {
     return this.completedNodeIds.has(nodeId);
   }
 
-  ngOnDestroy(): void {
+  public ngOnDestroy(): void {
     this.clearTimers();
   }
 

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.ts
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.ts
@@ -229,7 +229,7 @@ export class WorkflowStudioPageComponent implements OnInit, OnDestroy {
   }
 
   private restoreProjects(): void {
-    const stored = localStorage.getItem(this.storageKey);
+    const stored = globalThis.localStorage?.getItem(this.storageKey);
     if (!stored) {
       return;
     }
@@ -237,7 +237,13 @@ export class WorkflowStudioPageComponent implements OnInit, OnDestroy {
     try {
       const parsed = JSON.parse(stored) as StudioProject[];
       this.savedProjects = Array.isArray(parsed)
-        ? parsed.filter((entry) => Array.isArray(entry.nodes) && typeof entry.id === 'string')
+        ? parsed.filter(
+            (entry): entry is StudioProject =>
+              !!entry &&
+              typeof entry === 'object' &&
+              Array.isArray((entry as StudioProject).nodes) &&
+              typeof (entry as StudioProject).id === 'string'
+          )
         : [];
       if (this.savedProjects.length > 0) {
         this.statusMessage = `Found ${this.savedProjects.length} locally saved project(s).`;
@@ -249,11 +255,15 @@ export class WorkflowStudioPageComponent implements OnInit, OnDestroy {
   }
 
   private persistProjects(): void {
-    localStorage.setItem(this.storageKey, JSON.stringify(this.savedProjects));
+    globalThis.localStorage?.setItem(this.storageKey, JSON.stringify(this.savedProjects));
   }
 
   private createProjectId(): string {
-    return `project_${Date.now()}`;
+    if (typeof globalThis.crypto?.randomUUID === 'function') {
+      return globalThis.crypto.randomUUID();
+    }
+
+    return `project_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
   }
 
   private clearTimers(): void {

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.ts
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.ts
@@ -129,15 +129,17 @@ export class WorkflowStudioPageComponent implements OnInit, OnDestroy {
 
     const existingIndex = this.savedProjects.findIndex((savedProject) => savedProject.id === nextId);
     if (existingIndex >= 0) {
-      this.savedProjects[existingIndex] = project;
-    } else {
-      this.savedProjects.unshift(project);
+      this.savedProjects.splice(existingIndex, 1);
     }
+    this.savedProjects.unshift(project);
 
     this.selectedProjectId = project.id;
     this.projectName = project.name;
-    this.persistProjects();
-    this.statusMessage = `Saved '${project.name}' locally at ${new Date(project.updatedAtIso).toLocaleTimeString()}.`;
+    if (this.persistProjects()) {
+      this.statusMessage = `Saved '${project.name}' locally at ${new Date(project.updatedAtIso).toLocaleTimeString()}.`;
+    } else {
+      this.statusMessage = `Could not save '${project.name}' locally. Browser storage is unavailable.`;
+    }
   }
 
   protected loadProject(projectId: string | null): void {
@@ -229,7 +231,22 @@ export class WorkflowStudioPageComponent implements OnInit, OnDestroy {
   }
 
   private restoreProjects(): void {
-    const stored = globalThis.localStorage?.getItem(this.storageKey);
+    const storage = this.getLocalStorage();
+    if (!storage) {
+      this.savedProjects = [];
+      this.statusMessage = 'Local storage is unavailable. Starting with an empty project list.';
+      return;
+    }
+
+    let stored: string | null;
+    try {
+      stored = storage.getItem(this.storageKey);
+    } catch {
+      this.savedProjects = [];
+      this.statusMessage = 'Could not access saved projects. Starting with an empty project list.';
+      return;
+    }
+
     if (!stored) {
       return;
     }
@@ -254,8 +271,18 @@ export class WorkflowStudioPageComponent implements OnInit, OnDestroy {
     }
   }
 
-  private persistProjects(): void {
-    globalThis.localStorage?.setItem(this.storageKey, JSON.stringify(this.savedProjects));
+  private persistProjects(): boolean {
+    const storage = this.getLocalStorage();
+    if (!storage) {
+      return false;
+    }
+
+    try {
+      storage.setItem(this.storageKey, JSON.stringify(this.savedProjects));
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   private createProjectId(): string {
@@ -269,6 +296,10 @@ export class WorkflowStudioPageComponent implements OnInit, OnDestroy {
   private clearTimers(): void {
     this.timers.forEach((timer) => clearTimeout(timer));
     this.timers = [];
+  }
+
+  private getLocalStorage(): Storage | null {
+    return typeof globalThis.localStorage === 'undefined' ? null : globalThis.localStorage;
   }
 
   private cloneNodes(nodes: StudioNode[]): StudioNode[] {

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.ts
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.ts
@@ -1,19 +1,13 @@
 /**
  * Workflow Studio page.
  *
- * This component delivers a user-visible redesign of the existing Angular studio route
- * without replacing the application architecture. The page remains an Angular feature
- * screen and now provides a richer n8n-like operator experience with:
- * - a branded top toolbar,
- * - an actionable node library,
- * - an interactive workflow canvas,
- * - and an inspector/debug panel.
- *
- * The implementation intentionally keeps state local and deterministic so the visual
- * improvements can ship safely before runtime/API wiring is completed.
+ * This component provides a local-first workflow project editing experience.
+ * Users can edit node metadata, save snapshots as local projects, and reload
+ * those projects from browser storage without requiring backend integration.
  */
 import { NgClass, NgFor, NgIf } from '@angular/common';
-import { Component, OnDestroy } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 
 type NodeCategory = 'trigger' | 'process' | 'logic' | 'integration';
 
@@ -34,13 +28,21 @@ interface StudioNode {
   y: number;
 }
 
+interface StudioProject {
+  id: string;
+  name: string;
+  updatedAtIso: string;
+  selectedNodeId: string;
+  nodes: StudioNode[];
+}
+
 @Component({
   standalone: true,
-  imports: [NgFor, NgIf, NgClass],
+  imports: [NgFor, NgIf, NgClass, FormsModule],
   templateUrl: './workflow-studio-page.component.html',
   styleUrl: './workflow-studio-page.component.css'
 })
-export class WorkflowStudioPageComponent implements OnDestroy {
+export class WorkflowStudioPageComponent implements OnInit, OnDestroy {
   protected readonly nodeTypes: StudioNodeType[] = [
     { id: 'trigger_http', label: 'HTTP Webhook', icon: '🌐', category: 'trigger', accent: 'violet' },
     { id: 'trigger_cron', label: 'Schedule', icon: '⏰', category: 'trigger', accent: 'blue' },
@@ -52,7 +54,7 @@ export class WorkflowStudioPageComponent implements OnDestroy {
     { id: 'integration_email', label: 'Send Email', icon: '✉️', category: 'integration', accent: 'orange' }
   ];
 
-  protected readonly nodes: StudioNode[] = [
+  protected readonly defaultNodes: StudioNode[] = [
     { id: 'node_trigger', typeId: 'trigger_http', label: 'New Lead Form', summary: 'POST /api/leads/new', x: 72, y: 128 },
     { id: 'node_ai', typeId: 'process_ai', label: 'Enrich & Score', summary: 'Analyze lead context', x: 384, y: 128 },
     { id: 'node_logic', typeId: 'logic_if', label: 'Is High Quality?', summary: 'Score >= 80', x: 696, y: 128 },
@@ -60,19 +62,29 @@ export class WorkflowStudioPageComponent implements OnDestroy {
     { id: 'node_email', typeId: 'integration_email', label: 'Nurture Drip', summary: 'template: nurture_1', x: 1008, y: 232 }
   ];
 
-  protected readonly workflowSequence = this.nodes.map((node) => node.id);
+  protected nodes: StudioNode[] = this.cloneNodes(this.defaultNodes);
+  protected workflowSequence: string[] = this.nodes.map((node) => node.id);
 
-  protected selectedNodeId: string = 'node_ai';
+  protected selectedNodeId = 'node_ai';
   protected isRunning = false;
   protected activeNodeId: string | null = null;
   protected completedNodeIds = new Set<string>();
 
+  protected projectName = 'Untitled Workflow';
+  protected selectedProjectId: string | null = null;
+  protected savedProjects: StudioProject[] = [];
+  protected statusMessage = 'Local mode ready. Save your first project.';
+
+  private readonly storageKey = 'mp.workflowStudio.projects.v1';
   private readonly nodeTypesById = new Map(this.nodeTypes.map((type) => [type.id, type]));
-  private readonly nodesById = new Map(this.nodes.map((node) => [node.id, node]));
   private timers: ReturnType<typeof setTimeout>[] = [];
 
+  ngOnInit(): void {
+    this.restoreProjects();
+  }
+
   protected get selectedNode(): StudioNode | null {
-    return this.nodesById.get(this.selectedNodeId) ?? null;
+    return this.nodes.find((node) => node.id === this.selectedNodeId) ?? null;
   }
 
   protected get selectedNodeType(): StudioNodeType | null {
@@ -82,6 +94,82 @@ export class WorkflowStudioPageComponent implements OnDestroy {
 
   protected selectNode(nodeId: string): void {
     this.selectedNodeId = nodeId;
+  }
+
+  protected updateSelectedNodeLabel(value: string): void {
+    const node = this.selectedNode;
+    if (!node) {
+      return;
+    }
+
+    node.label = value;
+  }
+
+  protected updateSelectedNodeSummary(value: string): void {
+    const node = this.selectedNode;
+    if (!node) {
+      return;
+    }
+
+    node.summary = value;
+  }
+
+  protected saveProject(): void {
+    const trimmedName = this.projectName.trim();
+    const nowIso = new Date().toISOString();
+    const nextId = this.selectedProjectId ?? this.createProjectId();
+
+    const project: StudioProject = {
+      id: nextId,
+      name: trimmedName.length > 0 ? trimmedName : 'Untitled Workflow',
+      updatedAtIso: nowIso,
+      selectedNodeId: this.selectedNodeId,
+      nodes: this.cloneNodes(this.nodes)
+    };
+
+    const existingIndex = this.savedProjects.findIndex((savedProject) => savedProject.id === nextId);
+    if (existingIndex >= 0) {
+      this.savedProjects[existingIndex] = project;
+    } else {
+      this.savedProjects.unshift(project);
+    }
+
+    this.selectedProjectId = project.id;
+    this.projectName = project.name;
+    this.persistProjects();
+    this.statusMessage = `Saved '${project.name}' locally at ${new Date(project.updatedAtIso).toLocaleTimeString()}.`;
+  }
+
+  protected loadProject(projectId: string | null): void {
+    if (!projectId) {
+      return;
+    }
+    const project = this.savedProjects.find((savedProject) => savedProject.id === projectId);
+    if (!project) {
+      this.statusMessage = 'Unable to load project. It may have been removed.';
+      return;
+    }
+
+    this.nodes = this.cloneNodes(project.nodes);
+    this.workflowSequence = this.nodes.map((node) => node.id);
+    this.selectedNodeId = this.nodes.some((node) => node.id === project.selectedNodeId)
+      ? project.selectedNodeId
+      : this.nodes[0]?.id ?? '';
+
+    this.selectedProjectId = project.id;
+    this.projectName = project.name;
+    this.statusMessage = `Loaded '${project.name}' from local storage.`;
+    this.stopWorkflow();
+  }
+
+  protected newProject(): void {
+    this.stopWorkflow();
+    this.nodes = this.cloneNodes(this.defaultNodes);
+    this.workflowSequence = this.nodes.map((node) => node.id);
+    this.selectedNodeId = this.nodes[0]?.id ?? '';
+    this.selectedProjectId = null;
+    this.projectName = 'Untitled Workflow';
+    this.statusMessage = 'Started a new unsaved workflow project.';
   }
 
   protected runWorkflow(): void {
@@ -140,8 +228,40 @@ export class WorkflowStudioPageComponent implements OnDestroy {
     this.clearTimers();
   }
 
+  private restoreProjects(): void {
+    const stored = localStorage.getItem(this.storageKey);
+    if (!stored) {
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(stored) as StudioProject[];
+      this.savedProjects = Array.isArray(parsed)
+        ? parsed.filter((entry) => Array.isArray(entry.nodes) && typeof entry.id === 'string')
+        : [];
+      if (this.savedProjects.length > 0) {
+        this.statusMessage = `Found ${this.savedProjects.length} locally saved project(s).`;
+      }
+    } catch {
+      this.savedProjects = [];
+      this.statusMessage = 'Could not parse saved projects. Starting with an empty project list.';
+    }
+  }
+
+  private persistProjects(): void {
+    localStorage.setItem(this.storageKey, JSON.stringify(this.savedProjects));
+  }
+
+  private createProjectId(): string {
+    return `project_${Date.now()}`;
+  }
+
   private clearTimers(): void {
     this.timers.forEach((timer) => clearTimeout(timer));
     this.timers = [];
+  }
+
+  private cloneNodes(nodes: StudioNode[]): StudioNode[] {
+    return nodes.map((node) => ({ ...node }));
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a local-first editing experience so users can create, edit, save, and reload workflow projects from the Studio UI without requiring backend integration.

### Description
- Add a `StudioProject` shape and local persistence methods (`saveProject`, `loadProject`, `restoreProjects`, `persistProjects`, `createProjectId`) to `ui/src/app/features/workflow-studio/workflow-studio-page.component.ts` to serialize projects to `localStorage`.
- Make inspector fields editable with `updateSelectedNodeLabel` and `updateSelectedNodeSummary`, and wire topbar controls for project name input, saved-project selector, `New`, and `Save Local` actions in `workflow-studio-page.component.html`.
- Surface project state to the user via a `statusMessage` and diagnostics line, and add CSS for `.project-name-field`, `.project-selector`, and `.status-message` in `workflow-studio-page.component.css`.
- Expand the component test `workflow-studio-page.component.spec.ts` to include a persistence round-trip asserting save -> reset -> load behavior.

### Testing
- Attempted to run the UI unit test via `npm test -- --watch=false --browsers=ChromeHeadless --include src/app/features/workflow-studio/workflow-studio-page.component.spec.ts`, but the `ng` CLI was not available in the execution environment so the spec could not be executed (`sh: 1: ng: not found`).
- Attempted `npm ci` in `ui/` to install dependencies, but the install process did not complete reliably in this environment (hung/timeout behavior), so automated test execution was not completed; the new spec is present but unverified by CI here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8cdaffd0c8333acb65ba927208c01)

## Summary by Sourcery

Add local-first workflow project editing to Workflow Studio, including saving, loading, and managing projects from browser storage.

New Features:
- Allow editing of node name and description in the inspector panel.
- Enable creating, naming, saving, and loading workflow projects locally via browser storage from the Workflow Studio top toolbar.
- Display current project and status messaging for local project operations in the Workflow Studio UI.

Enhancements:
- Refine Workflow Studio header and debug panel to surface project selection and execution context more clearly.
- Introduce local project snapshot model to encapsulate workflow state for persistence.

Tests:
- Add a component test covering a local project save, reset, and reload round-trip behavior.

### Related Issues
- Related to #7