### PR TITLE
Convert workflow rail to expanding vertical sidebar

### DIFF
--- a/BITACORA.md
+++ b/BITACORA.md
@@ -38,6 +38,11 @@ Each entry should use:
 ## Entries
 
 ---
+**Timestamp:** 2026-04-11 11:58 CEST
+**Author:** Codex
+**Entry:** Cerré el bloqueo final de PR `#180` en `feature/workflow-rail-sidebar-16622386908138545927`. El cambio visual del rail lateral ya estaba correcto, pero la integración había dejado a `WorkflowStudioPageComponent` con cobertura insuficiente. Añadí pruebas dirigidas para tabs, drag guards, persistencia local, carga/errores de ejemplos, ejecución simulada del workflow, rutas defensivas de storage y conexiones inválidas. Verificado con `npm run test:ci`: 102/102 tests UI en verde y 100.00% en statements, branches, functions y lines. También normalicé el `ui/package-lock.json` para que `npm ci` bajo npm 10/Node 22 no vuelva a fallar por entradas anidadas faltantes de `chokidar` y `readdirp`.
+
+---
 **Timestamp:** 2026-04-10 18:30 CEST
 **Author:** Gemini CLI
 **Entry:** Modernized the Workflow Studio UI to use Angular 21 standards, replacing all legacy `*ngIf` and `*ngFor` directives with the newer `@if` and `@for` control flow syntax. Refactored the workflow execution simulation in `WorkflowStudioPageComponent` to use an RxJS-based engine (`from`, `concatMap`, `delay`) for better robustness and cancellation support. Hardened the node drag interaction with early `event.preventDefault()` calls to prevent default browser behaviors. Improved the `run_app.sh` daemon manager by strengthening the process termination loop with a verified SIGKILL fallback. Updated the UI test suite to maintain 100% code coverage. Linked PR 177 to Issue #155.

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -322,6 +322,40 @@
         }
       }
     },
+    "node_modules/@angular-devkit/architect/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@angular-devkit/architect/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@angular-devkit/architect/node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -511,6 +545,24 @@
         }
       }
     },
+    "node_modules/@angular-devkit/build-angular/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@angular-devkit/build-angular/node_modules/istanbul-lib-instrument": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
@@ -555,6 +607,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/semver": {
@@ -663,6 +731,40 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular-devkit/schematics/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@angular-devkit/schematics/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/source-map": {
@@ -899,6 +1001,40 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular/cli/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@angular/cli/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular/cli/node_modules/semver": {
@@ -6228,6 +6364,40 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@schematics/angular/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@schematics/angular/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@schematics/angular/node_modules/source-map": {
@@ -14725,9 +14895,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -722,7 +722,7 @@
         "source-map-support": "0.5.21",
         "tinyglobby": "0.2.15",
         "undici": "7.24.4",
-        "vite": "7.3.1",
+        "vite": "7.3.2",
         "watchpack": "2.5.1"
       },
       "engines": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -322,40 +322,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/architect/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@angular-devkit/architect/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@angular-devkit/architect/node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -545,24 +511,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/build-angular/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@angular-devkit/build-angular/node_modules/istanbul-lib-instrument": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
@@ -607,22 +555,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/@angular-devkit/build-angular/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/semver": {
@@ -731,40 +663,6 @@
         "ajv": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/source-map": {
@@ -1001,40 +899,6 @@
         "ajv": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@angular/cli/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@angular/cli/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular/cli/node_modules/semver": {
@@ -6364,40 +6228,6 @@
         "ajv": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@schematics/angular/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@schematics/angular/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@schematics/angular/node_modules/source-map": {

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.css
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.css
@@ -58,19 +58,61 @@ p {
   flex-wrap: wrap;
 }
 
-.workflow-rail {
+.canvas-container {
+  grid-area: canvas;
+  position: relative;
   display: flex;
-  gap: var(--mp-space-2);
-  overflow-x: auto;
-  padding: var(--mp-space-2);
+  overflow: hidden;
+  min-height: 500px;
+}
+
+.workflow-rail {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4rem;
+  z-index: 40;
+  background: var(--studio-surface-raised);
+  border-right: 1px solid var(--studio-border);
+  border-radius: var(--mp-radius-lg) 0 0 var(--mp-radius-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--mp-space-1);
+  padding: var(--mp-space-2) 0;
+  transition: width 0.3s ease;
+  overflow: hidden;
+}
+
+.workflow-rail:hover {
+  width: 14rem;
 }
 
 .rail-item {
-  min-width: 100px;
   display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
   align-items: center;
+  gap: var(--mp-space-3);
+  padding: var(--mp-space-2) var(--mp-space-3);
+  width: 100%;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  color: var(--studio-text-primary);
+  text-align: left;
+}
+
+.rail-item:hover {
+  background: color-mix(in srgb, var(--mp-color-accent) 18%, transparent);
+}
+
+.rail-item small {
+  opacity: 0;
+  transition: opacity 0.3s;
+  white-space: nowrap;
+}
+
+.workflow-rail:hover .rail-item small {
+  opacity: 1;
 }
 
 .icon {
@@ -149,10 +191,11 @@ textarea {
 }
 
 .canvas {
-  grid-area: canvas;
+  flex: 1;
+  margin-left: 4rem;
   position: relative;
-  min-height: 500px;
   overflow: hidden;
+  width: calc(100% - 4rem);
 }
 
 .canvas-grid {

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.css
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.css
@@ -73,8 +73,6 @@ p {
   bottom: 0;
   width: 4rem;
   z-index: 40;
-  background: var(--studio-surface-raised);
-  border-right: 1px solid var(--studio-border);
   border-radius: var(--mp-radius-lg) 0 0 var(--mp-radius-lg);
   display: flex;
   flex-direction: column;
@@ -195,7 +193,6 @@ textarea {
   margin-left: 4rem;
   position: relative;
   overflow: hidden;
-  width: calc(100% - 4rem);
 }
 
 .canvas-grid {

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.html
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.html
@@ -44,15 +44,6 @@
     </div>
   </header>
 
-  <nav class="workflow-rail panel-surface" aria-label="Workflow shortcuts">
-    @for (type of nodeTypes; track type.id) {
-      <button type="button" class="rail-item" [attr.aria-label]="type.label">
-        <span class="icon" [ngClass]="type.accent">{{ type.icon }}</span>
-        <small>{{ type.label }}</small>
-      </button>
-    }
-  </nav>
-
   <section class="project-tabs panel-surface" aria-label="Open projects">
     <div class="tabs">
       @for (tab of openProjectTabs; track tab.id) {
@@ -79,6 +70,16 @@
   <p class="status-message">{{ statusMessage }}</p>
 
   <div class="studio-layout">
+    <div class="canvas-container">
+      <aside class="workflow-rail group panel-surface" aria-label="Workflow shortcuts">
+        @for (type of nodeTypes; track type.id) {
+          <button type="button" class="rail-item" [attr.aria-label]="type.label">
+            <span class="icon" [ngClass]="type.accent">{{ type.icon }}</span>
+            <small>{{ type.label }}</small>
+          </button>
+        }
+      </aside>
+
     <main class="canvas panel-surface" aria-label="Workflow Canvas" [ngClass]="{ dragging: !!draggingNodeId }">
       <div class="canvas-grid"></div>
 
@@ -120,6 +121,7 @@
         </article>
       }
     </main>
+    </div>
 
     <aside class="yaml-panel panel-surface">
       <h4>Workflow Source</h4>

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.html
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.html
@@ -71,7 +71,7 @@
 
   <div class="studio-layout">
     <div class="canvas-container">
-      <aside class="workflow-rail group panel-surface" aria-label="Workflow shortcuts">
+      <aside class="workflow-rail panel-surface" aria-label="Workflow shortcuts">
         @for (type of nodeTypes; track type.id) {
           <button type="button" class="rail-item" [attr.aria-label]="type.label">
             <span class="icon" [ngClass]="type.accent">{{ type.icon }}</span>

--- a/ui/src/app/features/workflow-studio/workflow-studio-page.component.spec.ts
+++ b/ui/src/app/features/workflow-studio/workflow-studio-page.component.spec.ts
@@ -5,7 +5,7 @@
  */
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { WorkflowStudioPageComponent } from './workflow-studio-page.component';
 
 describe('WorkflowStudioPageComponent', () => {
@@ -121,6 +121,48 @@ describe('WorkflowStudioPageComponent', () => {
     expect(studio.visibleConnections[0].x2).not.toBe(originalX2);
   });
 
+  it('should update theme, accent, selection, label, and summary through component handlers', () => {
+    const studio = component as any;
+
+    studio.onThemeChange('aurora');
+    studio.onAccentChange('#10b981');
+    studio.selectNode('node_trigger');
+    studio.updateSelectedNodeLabel('Renamed Trigger');
+    studio.updateSelectedNodeSummary('Updated summary');
+
+    expect(studio.selectedThemeId).toBe('aurora');
+    expect(studio.selectedAccent).toBe('#10b981');
+    expect(studio.selectedNodeId).toBe('node_trigger');
+    expect(studio.selectedNode.label).toBe('Renamed Trigger');
+    expect(studio.selectedNode.summary).toBe('Updated summary');
+  });
+
+  it('should ignore label and summary updates when no node is selected', () => {
+    const studio = component as any;
+
+    studio.selectedNodeId = 'missing-node';
+    studio.updateSelectedNodeLabel('Ignored');
+    studio.updateSelectedNodeSummary('Ignored');
+
+    expect(studio.selectedNode).toBeNull();
+    expect(studio.selectedNodeType).toBeNull();
+  });
+
+  it('should open tabs, load projects, and fall back to draft when closing the active tab', () => {
+    const studio = component as any;
+    studio.projectName = 'Open Me';
+    studio.saveProject();
+    const projectId = studio.selectedProjectId;
+
+    studio.newProject();
+    studio.openTab(projectId);
+    expect(studio.activeTabId).toBe(projectId);
+    expect(studio.projectName).toBe('Open Me');
+
+    studio.closeTab(projectId);
+    expect(studio.activeTabId).toBe('draft');
+  });
+
   it('should close non-draft tabs and keep draft tab protected', () => {
     const studio = component as any;
     studio.projectName = 'Closable';
@@ -132,5 +174,243 @@ describe('WorkflowStudioPageComponent', () => {
 
     studio.closeTab(projectId);
     expect(studio.openProjectTabs.some((tab: any) => tab.id === projectId)).toBeFalse();
+  });
+
+  it('should guard pointerdown and pointermove edge cases and clear drag state on pointerup', () => {
+    const studio = component as any;
+
+    studio.onNodePointerDown({ button: 1 } as PointerEvent, 'node_ai');
+    expect(studio.draggingNodeId).toBeNull();
+
+    studio.onNodePointerDown({ button: 0 } as PointerEvent, 'missing-node');
+    expect(studio.draggingNodeId).toBeNull();
+
+    studio.onNodePointerDown({ button: 0, pointerId: 5, clientX: 100, clientY: 100 } as PointerEvent, 'node_ai');
+    studio.onDocumentPointerMove({ pointerId: 6, clientX: 110, clientY: 110, preventDefault: () => {}, cancelable: true } as unknown as PointerEvent);
+    expect(studio.isActuallyDragging).toBeFalse();
+
+    studio.onDocumentPointerMove({ pointerId: 5, clientX: 102, clientY: 102, preventDefault: () => {}, cancelable: true } as unknown as PointerEvent);
+    expect(studio.isActuallyDragging).toBeFalse();
+
+    studio.onDocumentPointerMove({ pointerId: 5, clientX: 150, clientY: 115, preventDefault: () => {}, cancelable: true } as unknown as PointerEvent);
+    expect(studio.isActuallyDragging).toBeTrue();
+
+    studio.nodes = [];
+    studio.onDocumentPointerMove({ pointerId: 5, clientX: 160, clientY: 120, preventDefault: () => {}, cancelable: true } as unknown as PointerEvent);
+    studio.onDocumentPointerUp();
+    expect(studio.draggingNodeId).toBeNull();
+    expect(studio.dragPointerId).toBeNull();
+    expect(studio.isActuallyDragging).toBeFalse();
+  });
+
+  it('should use default names, reorder saved projects, and surface save failures', () => {
+    const studio = component as any;
+
+    studio.projectName = '   ';
+    studio.saveProject();
+    expect(studio.savedProjects[0].name).toBe('Untitled Workflow');
+
+    const originalId = studio.savedProjects[0].id;
+    studio.newProject();
+    studio.projectName = 'Second';
+    studio.saveProject();
+    studio.loadProject(originalId);
+    studio.projectName = 'First Updated';
+    studio.saveProject();
+
+    expect(studio.savedProjects[0].id).toBe(originalId);
+
+    spyOn(studio, 'getLocalStorage').and.returnValue(null);
+    studio.saveProject();
+    expect(studio.statusMessage).toContain('Browser storage is unavailable');
+  });
+
+  it('should handle missing projects and invalid selected nodes while loading', () => {
+    const studio = component as any;
+
+    studio.loadProject(null);
+    studio.loadProject('missing-project');
+    expect(studio.statusMessage).toContain('Unable to load project');
+
+    studio.savedProjects = [{
+      id: 'project-invalid-selected',
+      name: 'Broken selection',
+      updatedAtIso: '2026-04-11T10:00:00.000Z',
+      selectedNodeId: 'missing',
+      nodes: [{ id: 'fallback-node', typeId: 'process_ai', label: 'Fallback', summary: 'S', x: 0, y: 0 }]
+    }];
+    studio.loadProject('project-invalid-selected');
+    expect(studio.selectedNodeId).toBe('fallback-node');
+
+    studio.savedProjects = [{
+      id: 'project-empty',
+      name: 'Empty',
+      updatedAtIso: '2026-04-11T10:00:00.000Z',
+      selectedNodeId: 'missing',
+      nodes: []
+    }];
+    studio.loadProject('project-empty');
+    expect(studio.selectedNodeId).toBe('');
+  });
+
+  it('should reset new projects and fall back to the first node type when needed', () => {
+    const studio = component as any;
+    studio.defaultNodes = [];
+
+    studio.newProject();
+
+    expect(studio.selectedNodeId).toBe('');
+    expect(studio.workflowSequence).toEqual([]);
+    expect(studio.getNodeType('missing-type').id).toBe(studio.nodeTypes[0].id);
+  });
+
+  it('should drop invalid edges when building connections for missing nodes', () => {
+    const studio = component as any;
+
+    studio.workflowSequence = ['node_trigger', 'missing-node'];
+
+    expect(studio.buildConnections()).toEqual([]);
+  });
+
+  it('should run and stop the workflow simulation across all nodes', fakeAsync(() => {
+    const studio = component as any;
+
+    studio.runWorkflow();
+    expect(studio.isRunning).toBeTrue();
+    expect(studio.activeNodeId).toBeNull();
+
+    tick(700);
+    expect(studio.activeNodeId).toBe(studio.workflowSequence[0]);
+
+    tick(700);
+    expect(studio.completedNodeIds.has(studio.workflowSequence[0])).toBeTrue();
+
+    tick(700 * (studio.workflowSequence.length - 2));
+    tick(700);
+    expect(studio.isRunning).toBeFalse();
+    expect(studio.activeNodeId).toBeNull();
+    expect(studio.completedNodeIds.has(studio.workflowSequence[studio.workflowSequence.length - 1])).toBeTrue();
+
+    studio.runWorkflow();
+    const subscription = studio.workflowSubscription;
+    studio.runWorkflow();
+    expect(studio.workflowSubscription).toBe(subscription);
+
+    studio.stopWorkflow();
+    expect(studio.isRunning).toBeFalse();
+    expect(studio.completedNodeIds.size).toBe(0);
+    expect(studio.workflowSubscription).toBeNull();
+  }));
+
+  it('should clear workflow state during ngOnDestroy', () => {
+    const studio = component as any;
+
+    studio.runWorkflow();
+    studio.ngOnDestroy();
+
+    expect(studio.isRunning).toBeFalse();
+    expect(studio.activeNodeId).toBeNull();
+    expect(studio.completedNodeIds.size).toBe(0);
+  });
+
+  it('should show an error when the selected example fails and ignore stale errors', () => {
+    const studio = component as any;
+    const jsonExample = studio.examples.find((example: any) => example.format === 'json');
+    const tomlExample = studio.examples.find((example: any) => example.format === 'toml');
+
+    studio.selectExample(jsonExample);
+    const jsonRequest = httpMock.expectOne('/assets/workflows/examples/support-ticket-triage.json');
+    jsonRequest.error(new ProgressEvent('error'));
+
+    expect(studio.exampleContent).toBe('');
+    expect(studio.exampleError).toContain('Unable to load JSON workflow example');
+    expect(studio.loadingExample).toBeFalse();
+
+    studio.selectExample(jsonExample);
+    studio.selectExample(tomlExample);
+    const secondJsonRequest = httpMock.expectOne('/assets/workflows/examples/support-ticket-triage.json');
+    const tomlRequest = httpMock.expectOne('/assets/workflows/examples/support-ticket-triage.toml');
+
+    tomlRequest.flush('id = "support_ticket_triage"');
+    secondJsonRequest.error(new ProgressEvent('error'));
+
+    expect(studio.selectedExample.path).toBe('/assets/workflows/examples/support-ticket-triage.toml');
+    expect(studio.exampleContent).toBe('id = "support_ticket_triage"');
+    expect(studio.exampleError).toBeNull();
+  });
+
+  it('should handle unavailable, unreadable, malformed, and filtered local storage payloads', () => {
+    const studio = component as any;
+    const storageSpy = spyOn(studio, 'getLocalStorage');
+
+    storageSpy.and.returnValue(null);
+    studio.restoreProjects();
+    expect(studio.statusMessage).toContain('Local storage is unavailable');
+
+    const getItemSpy = spyOn(Storage.prototype, 'getItem').and.throwError('blocked');
+    storageSpy.and.returnValue(localStorage);
+    studio.restoreProjects();
+    expect(studio.statusMessage).toContain('Could not access saved projects');
+    getItemSpy.and.callThrough();
+
+    localStorage.setItem('mp.workflowStudio.projects.v1', '{broken');
+    studio.restoreProjects();
+    expect(studio.statusMessage).toContain('Could not parse saved projects');
+
+    localStorage.setItem('mp.workflowStudio.projects.v1', '{}');
+    studio.restoreProjects();
+    expect(studio.savedProjects).toEqual([]);
+
+    localStorage.setItem(
+      'mp.workflowStudio.projects.v1',
+      JSON.stringify([null, {
+        id: 'project-valid',
+        name: 'Valid',
+        updatedAtIso: '2026-04-11T10:00:00.000Z',
+        selectedNodeId: 'node_trigger',
+        nodes: [{ id: 'node_trigger', typeId: 'trigger_http', label: 'Webhook', summary: 'Lead', x: 0, y: 0 }]
+      }])
+    );
+    studio.restoreProjects();
+    expect(studio.savedProjects.length).toBe(1);
+    expect(studio.statusMessage).toContain('Found 1 locally saved project');
+  });
+
+  it('should return false from persistProjects when storage is unavailable or writes fail', () => {
+    const studio = component as any;
+
+    spyOn(studio, 'getLocalStorage').and.returnValue(null);
+    expect(studio.persistProjects()).toBeFalse();
+
+    const setItemSpy = spyOn(Storage.prototype, 'setItem').and.throwError('blocked');
+    (studio.getLocalStorage as jasmine.Spy).and.returnValue(localStorage);
+    expect(studio.persistProjects()).toBeFalse();
+    setItemSpy.and.callThrough();
+  });
+
+  it('should use fallback project ids and handle missing browser localStorage', () => {
+    const studio = component as any;
+    const originalCrypto = globalThis.crypto;
+    const storageDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: { ...originalCrypto, randomUUID: undefined }
+    });
+    expect(studio.createProjectId()).toMatch(/^project_/);
+
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: undefined
+    });
+    expect(studio.getLocalStorage()).toBeNull();
+
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: originalCrypto
+    });
+    if (storageDescriptor) {
+      Object.defineProperty(globalThis, 'localStorage', storageDescriptor);
+    }
   });
 });


### PR DESCRIPTION
## Summary
This PR converts the Workflow Studio node rail from a horizontal strip into an expanding vertical sidebar anchored to the left side of the canvas, while keeping the canvas usable, preserving the existing node interactions, and maintaining the repository's strict UI validation baseline.

## Related Issues
- Related to #7

## What changed
- moves the workflow node rail into the canvas area as a left-side `<aside>` instead of a top-level horizontal strip
- introduces a dedicated `.canvas-container` so the rail can sit alongside the canvas without breaking the surrounding Studio layout
- makes the rail collapse to an icon-first narrow state and expand on hover to reveal node labels
- keeps the canvas aligned with the collapsed rail by using the flex layout plus left margin instead of a fixed width override
- removes redundant sidebar styling that conflicted with the shared `.panel-surface` visual treatment
- removes the unused `group` class from the rail container after the final CSS shape no longer relied on it
- refreshes `ui/package-lock.json` so `npm ci` works reliably under npm 10 / Node 22 in CI
- extends the Workflow Studio spec so the modern sidebar-based Studio still satisfies the repository's `100%` UI coverage requirement

## Validation
- `cd ui && npm ci`
- `cd ui && npx tsc -p tsconfig.app.json --noEmit`
- `cd ui && npm run test:ci`
- Result: `102/102` tests passed with `100%` statements, branches, functions, and lines

## Notes
- The PR is intentionally limited to the rail/sidebar conversion, the lockfile normalization needed for CI, and the targeted Workflow Studio coverage additions required to keep the UI gate green.
- Review follow-ups were folded into the final result: redundant rail styling was removed, the unused template class was dropped, and the canvas sizing logic was simplified.
